### PR TITLE
fixes integer overflow while bitwise shifting

### DIFF
--- a/Sources/RSocketCore/Frame Header/FrameHeaderEncoder.swift
+++ b/Sources/RSocketCore/Frame Header/FrameHeaderEncoder.swift
@@ -25,7 +25,7 @@ internal struct FrameHeaderEncoder: FrameHeaderEncoding {
         var buffer = allocator.buffer(capacity: FrameHeader.lengthInBytes)
         buffer.writeInteger(header.streamId)
         // shift type by amount of flag bits
-        let typeBits = UInt16(header.type.rawValue << 10)
+        let typeBits = UInt16(header.type.rawValue) << 10
         // only use trailing 10 bits for flags
         let flagBits = header.flags.rawValue & 0b0000001111111111
         buffer.writeInteger(typeBits | flagBits)


### PR DESCRIPTION
This line was doing bitwise shifting by 10 over an 8 bit integer, which will lead to integer overflow. We need to first type cast to UInt16 and then do shifting by 10.