### PR TITLE
fixes metadata length encoding.

### DIFF
--- a/Sources/RSocketCore/Utility/FixedWidthInteger+Bytes.swift
+++ b/Sources/RSocketCore/Utility/FixedWidthInteger+Bytes.swift
@@ -18,8 +18,8 @@ import Foundation
 
 extension FixedWidthInteger {
     internal var bytes: [UInt8] {
-        (0..<bitWidth)
-            .map { UInt8(truncatingIfNeeded: self >> $0) }
+        (0..<(bitWidth / UInt8.bitWidth))
+            .map { UInt8(truncatingIfNeeded: self >> ($0 * UInt8.bitWidth)) }
             .reversed()
     }
 }


### PR DESCRIPTION
These current lines will write the number, the number bitwise right shifted by 1 and the number bitwise right shifted by 2. Instead we want to write a 24 bit number, divided into 3 bytes. So we should be right shifting by 16, getting the first 8 bits and writing it in the first byte. For second byte, we should do bitwise right shift by 8, get the first 8 bits and write it in the buffer. And for the third byte, we should pickup the first 8 bits of the number and write it.