### PR TITLE
implements metadata push

### DIFF
--- a/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
+++ b/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import Foundation
 import NIO
 
 /// The role of a connection
@@ -40,7 +41,10 @@ internal struct DemultiplexerRouter {
     
     internal var connectionSide: ConnectionRole
     
-    internal func route(for streamId: StreamID) -> Route {
+    internal func route(for streamId: StreamID, type: FrameType) -> Route {
+        guard type != .metadataPush else {
+            return .responder
+        }
         switch (streamId.generatedBy, connectionSide) {
         case (nil, _):
             return .connection
@@ -68,7 +72,7 @@ internal final class DemultiplexerHandler: ChannelInboundHandler {
     
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let frame = unwrapInboundIn(data)
-        switch router.route(for: frame.header.streamId) {
+        switch router.route(for: frame.header.streamId, type: frame.header.type) {
         case .connection:
             context.fireChannelRead(wrapInboundOut(frame))
         case .requester:
@@ -80,8 +84,8 @@ internal final class DemultiplexerHandler: ChannelInboundHandler {
 }
 
 extension DemultiplexerHandler: RSocket {
-    func metadataPush(payload: Payload) {
-        fatalError("not implemented")
+    func metadataPush(metadata: Data) {
+        requester.metadataPush(metadata: metadata)
     }
     
     func fireAndForget(payload: Payload) {

--- a/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
+++ b/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
@@ -42,11 +42,11 @@ internal struct DemultiplexerRouter {
     internal var connectionSide: ConnectionRole
     
     internal func route(for streamId: StreamID, type: FrameType) -> Route {
-        guard type != .metadataPush else {
-            return .responder
-        }
         switch (streamId.generatedBy, connectionSide) {
-        case (nil, _):
+        case (nil, _):    
+            guard type != .metadataPush else {
+                return .responder
+            }
             return .connection
         case (.client, .client), (.server, .server):
             return .requester

--- a/Sources/RSocketCore/RSocket.swift
+++ b/Sources/RSocketCore/RSocket.swift
@@ -17,8 +17,7 @@
 import Foundation
 
 public protocol RSocket {
-    
-    func metadataPush(payload: Payload)
+    func metadataPush(metadata: Data)
     
     func fireAndForget(payload: Payload)
     

--- a/Sources/RSocketCore/Streams/Requester.swift
+++ b/Sources/RSocketCore/Streams/Requester.swift
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import Foundation
 import NIO
 
 internal final class Requester {
@@ -59,7 +61,13 @@ extension Requester: StreamDelegate {
     }
 }
 
-extension Requester {
+extension Requester: RSocket {
+    func metadataPush(metadata: Data) {
+        eventLoop.execute { [self] in
+            send(frame: MetadataPushFrameBody(metadata: metadata).asFrame())
+        }
+    }
+
     func fireAndForget(payload: Payload) {
         eventLoop.execute { [self] in
             let newId = generateNewStreamId()

--- a/Sources/RSocketCore/Streams/Responder.swift
+++ b/Sources/RSocketCore/Streams/Responder.swift
@@ -37,6 +37,11 @@ internal final class Responder {
             existingStreamAdapter.receive(frame: frame)
             return
         }
+
+        if case let .metadataPush(body) = frame.body, streamId == .connection {
+            responderSocket.metadataPush(metadata: body.metadata)
+            return
+        }
         
         guard frame.header.type.canCreateStream else {
             // ignore frame because it could be a late frame

--- a/Tests/RSocketCoreTests/EndToEndTests.swift
+++ b/Tests/RSocketCoreTests/EndToEndTests.swift
@@ -20,7 +20,7 @@ import NIOExtras
 @testable import RSocketCore
 
 final class TestRSocket: RSocket {
-    var metadataPush: ((Payload) -> ())? = nil
+    var metadataPush: ((Data) -> ())? = nil
     var fireAndForget: ((_ payload: Payload) -> ())? = nil
     var requestResponse: ((_ payload: Payload, _ responderOutput: UnidirectionalStream) -> Cancellable)? = nil
     var stream: ((_ payload: Payload, _ initialRequestN: Int32, _ responderOutput: UnidirectionalStream) -> Subscription)? = nil
@@ -30,7 +30,7 @@ final class TestRSocket: RSocket {
     private let line: UInt
     
     internal init(
-        metadataPush: ((Payload) -> ())? = nil,
+        metadataPush: ((Data) -> ())? = nil,
         fireAndForget: ((Payload) -> ())? = nil,
         requestResponse: ((Payload, UnidirectionalStream) -> Cancellable)? = nil,
         stream: ((Payload, Int32, UnidirectionalStream) -> Subscription)? = nil,
@@ -48,12 +48,12 @@ final class TestRSocket: RSocket {
     }
     
     
-    func metadataPush(payload: Payload) {
+    func metadataPush(metadata: Data) {
         guard let metadataPush = metadataPush else {
             XCTFail("metadataPush not expected to be called ", file: file, line: line)
             return
         }
-        metadataPush(payload)
+        metadataPush(metadata)
     }
     
     func fireAndForget(payload: Payload) {


### PR DESCRIPTION
This PR adds metadata push handling to both requester (send metadata push) and responder (receive metadata push). The demultiplexer will check the frame type and send all metadata push frames to the responder.