### PR TITLE
exposes ChannelPipeline extensions API for RSocket setup

### DIFF
--- a/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
+++ b/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
@@ -82,25 +82,3 @@ internal final class DemultiplexerHandler: ChannelInboundHandler {
         }
     }
 }
-
-extension DemultiplexerHandler: RSocket {
-    func metadataPush(metadata: Data) {
-        requester.metadataPush(metadata: metadata)
-    }
-    
-    func fireAndForget(payload: Payload) {
-        requester.fireAndForget(payload: payload)
-    }
-    
-    func requestResponse(payload: Payload, responderStream: UnidirectionalStream) -> Cancellable {
-        requester.requestResponse(payload: payload, responderStream: responderStream)
-    }
-    
-    func stream(payload: Payload, initialRequestN: Int32, responderStream: UnidirectionalStream) -> Subscription {
-        requester.stream(payload: payload, initialRequestN: initialRequestN, responderStream: responderStream)
-    }
-    
-    func channel(payload: Payload, initialRequestN: Int32, isCompleted: Bool, responderStream: UnidirectionalStream) -> UnidirectionalStream {
-        requester.channel(payload: payload, initialRequestN: initialRequestN, isCompleted: isCompleted, responderStream: responderStream)
-    }
-}

--- a/Sources/RSocketCore/ChannelPipeline.swift
+++ b/Sources/RSocketCore/ChannelPipeline.swift
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIO
+
+extension ChannelPipeline {
+    public func addRSocketClientHandlers(
+        config: ClientSetupConfig,
+        responder: RSocket,
+        maximumFrameSize: Int32? = nil
+    ) -> EventLoopFuture<Void> {
+        let maximumFrameSize = maximumFrameSize ?? Payload.Constants.minMtuSize
+        let sendFrame: (Frame) -> () = { [weak self] frame in
+            self?.writeAndFlush(NIOAny(frame), promise: nil)
+        }
+        return addHandlers([
+            FrameDecoderHandler(),
+            FrameEncoderHandler(maximumFrameSize: maximumFrameSize),
+            SetupWriter(config: config),
+            DemultiplexerHandler(
+                connectionSide: .client,
+                requester: Requester(streamIdGenerator: .client, eventLoop: eventLoop, sendFrame: sendFrame),
+                responder: Responder(responderSocket: responder, eventLoop: eventLoop, sendFrame: sendFrame)
+            ),
+            ConnectionStreamHandler(),
+        ])
+    }
+}
+
+extension ChannelPipeline {
+    public func addRSocketServerHandlers(
+        shouldAcceptClient: ClientAcceptorCallback? = nil,
+        makeResponder: @escaping (SetupInfo) -> RSocket,
+        maximumFrameSize: Int32? = nil
+    ) -> EventLoopFuture<Void> {
+        let maximumFrameSize = maximumFrameSize ?? Payload.Constants.minMtuSize
+        return addHandlers([
+            FrameDecoderHandler(),
+            FrameEncoderHandler(maximumFrameSize: maximumFrameSize),
+            ConnectionEstablishmentHandler(initializeConnection: { [unowned self] (info, channel) in
+                let responder = makeResponder(info)
+                let sendFrame: (Frame) -> () = { [weak self] frame in
+                    self?.writeAndFlush(NIOAny(frame), promise: nil)
+                }
+                return channel.pipeline.addHandlers([
+                    DemultiplexerHandler(
+                        connectionSide: .server,
+                        requester: Requester(streamIdGenerator: .server, eventLoop: eventLoop, sendFrame: sendFrame),
+                        responder: Responder(responderSocket: responder, eventLoop: eventLoop, sendFrame: sendFrame)
+                    ),
+                    ConnectionStreamHandler(),
+                ])
+            }, shouldAcceptClient: shouldAcceptClient)
+        ])
+    }
+}
+
+extension ChannelPipeline {
+    public func requesterSocket() -> EventLoopFuture<RSocket> {
+        self.handler(type: DemultiplexerHandler.self).map({ $0.requester as RSocket })
+    }
+}

--- a/Sources/RSocketCore/DefaultRSocket.swift
+++ b/Sources/RSocketCore/DefaultRSocket.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// A stream which does not do anything.
+fileprivate final class NoOpStream: UnidirectionalStream {
+    func onNext(_ payload: Payload, isCompletion: Bool) {}
+    func onError(_ error: Error) {}
+    func onComplete() {}
+    func onExtension(extendedType: Int32, payload: Payload, canBeIgnored: Bool) {}
+    func onRequestN(_ requestN: Int32) {}
+    func onCancel() {}
+}
+
+
+/// An RSocket which rejects all incoming requests (requestResponse, stream and channel) and ignores metadataPush and fireAndForget events.
+internal struct DefaultRSocket: RSocket {
+    func metadataPush(metadata: Data) {}
+    func fireAndForget(payload: Payload) {}
+    func requestResponse(payload: Payload, responderStream: UnidirectionalStream) -> Cancellable {
+        responderStream.onError(.rejected(message: "not implemented"))
+        return NoOpStream()
+    }
+    func stream(payload: Payload, initialRequestN: Int32, responderStream: UnidirectionalStream) -> Subscription {
+        responderStream.onError(.rejected(message: "not implemented"))
+        return NoOpStream()
+    }
+    func channel(payload: Payload, initialRequestN: Int32, isCompleted: Bool, responderStream: UnidirectionalStream) -> UnidirectionalStream {
+        responderStream.onError(.rejected(message: "not implemented"))
+        return NoOpStream()
+    }
+}


### PR DESCRIPTION
Add Public API to use `RSocketCore` without `@testable import`.
> Note: This PR should be reviewed & merged after #21
### Motivation:
All `ChannelHandler`s are internal. There is no public API to actually add any `ChannelHandler`s to a `ChannelPipeline`.
This is needed if we want to write performance tests because they need to be build with optimisation and `@testable import` is not available in release configuration.
### Modifications:
Modifications:
- Add extension to `ChannelPipeline` to add RSocket client handlers
- Add extension to `ChannelPipeline` to add RSocket server handlers
- Add extension to `ChannelPipeline` to get requester `RSocket` from a connected connection

### Result:
`Core` can now be used without `@testable import` 