### PR TITLE
implements ConnectionStateHandler

### DIFF
--- a/Sources/RSocketCore/Channel Handler/ConnectionStateHandler.swift
+++ b/Sources/RSocketCore/Channel Handler/ConnectionStateHandler.swift
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import NIO
+
+internal final class ConnectionStateHandler {
+    private var isConnectionClosed = false
+}
+
+extension ConnectionStateHandler: ChannelInboundHandler {
+    typealias InboundIn = Frame
+    typealias InboundOut = Frame
+
+    internal func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let frame = unwrapInboundIn(data)
+        switch (frame.header.streamId, frame.header.type) {
+        case (.connection, .error):
+            context.close(mode: .all).whenComplete { _ in
+                context.fireChannelRead(data)
+            }
+        default:
+            context.fireChannelRead(data)
+        }
+    }
+}
+
+extension ConnectionStateHandler: ChannelOutboundHandler {
+    typealias OutboundIn = Frame
+    typealias OutboundOut = Frame
+
+    internal func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        guard !isConnectionClosed else { return }
+        let future = context.write(data)
+        let frame = unwrapOutboundIn(data)
+        switch (frame.header.streamId, frame.header.type) {
+        case (.connection, .error):
+            isConnectionClosed = true
+            future.flatMap {
+                context.close(mode: .all)
+            }.cascade(to: promise)
+        default:
+            future.cascade(to: promise)
+        }
+    }
+}

--- a/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
+++ b/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
@@ -34,12 +34,12 @@ extension StreamID {
 
 internal struct DemultiplexerRouter {
     internal struct Route: OptionSet {
-        internal let rawValue: UInt8
-
         internal static let connection = Route(rawValue: 1 << 0)
         internal static let requester = Route(rawValue: 1 << 1)
         internal static let responder = Route(rawValue: 1 << 2)
         internal static let all: Route = [connection, requester, responder]
+
+        internal let rawValue: UInt8
     }
     
     internal var connectionSide: ConnectionRole

--- a/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
+++ b/Sources/RSocketCore/Channel Handler/DemultiplexerHandler.swift
@@ -33,21 +33,28 @@ extension StreamID {
 }
 
 internal struct DemultiplexerRouter {
-    internal enum Route {
-        case connection
-        case requester
-        case responder
+    internal struct Route: OptionSet {
+        internal let rawValue: UInt8
+
+        internal static let connection = Route(rawValue: 1 << 0)
+        internal static let requester = Route(rawValue: 1 << 1)
+        internal static let responder = Route(rawValue: 1 << 2)
+        internal static let all: Route = [connection, requester, responder]
     }
     
     internal var connectionSide: ConnectionRole
     
     internal func route(for streamId: StreamID, type: FrameType) -> Route {
         switch (streamId.generatedBy, connectionSide) {
-        case (nil, _):    
-            guard type != .metadataPush else {
+        case (nil, _):
+            switch type {
+            case .metadataPush:
                 return .responder
+            case .error:
+                return .all
+            default:
+                return .connection
             }
-            return .connection
         case (.client, .client), (.server, .server):
             return .requester
         case (.client, .server), (.server, .client):
@@ -72,12 +79,14 @@ internal final class DemultiplexerHandler: ChannelInboundHandler {
     
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let frame = unwrapInboundIn(data)
-        switch router.route(for: frame.header.streamId, type: frame.header.type) {
-        case .connection:
+        let route = router.route(for: frame.header.streamId, type: frame.header.type)
+        if route.contains(.connection) {
             context.fireChannelRead(wrapInboundOut(frame))
-        case .requester:
+        }
+        if route.contains(.requester) {
             requester.receiveInbound(frame: frame)
-        case .responder:
+        }
+        if route.contains(.responder) {
             responder.receiveInbound(frame: frame)
         }
     }

--- a/Sources/RSocketCore/Streams/Requester.swift
+++ b/Sources/RSocketCore/Streams/Requester.swift
@@ -43,6 +43,10 @@ internal final class Requester {
 
     internal func receiveInbound(frame: Frame) {
         let streamId = frame.header.streamId
+        if streamId == .connection && frame.header.type == .error {
+            activeStreams.values.forEach { $0.receive(frame: frame) }
+            return
+        }
         guard let existingStreamAdapter = activeStreams[streamId] else {
             // TODO: do not close connection for late frames
             send(frame: Error.connectionError(message: "No active stream for given id").asFrame(withStreamId: streamId))

--- a/Sources/RSocketCore/Streams/Responder.swift
+++ b/Sources/RSocketCore/Streams/Responder.swift
@@ -33,6 +33,10 @@ internal final class Responder {
 
     internal func receiveInbound(frame: Frame) {
         let streamId = frame.header.streamId
+        if streamId == .connection && frame.header.type == .error {
+            activeStreams.values.forEach { $0.receive(frame: frame) }
+            return
+        }
         if let existingStreamAdapter = activeStreams[streamId] {
             existingStreamAdapter.receive(frame: frame)
             return


### PR DESCRIPTION
This PR implements a `ConnectionStateHandler` that closes the connection when an error frame is received that has streamId `0`.
It also refactors the route handling of the demultiplexer so that it now supports multiple recipients for a single frame.