### PR TITLE
improves CI Testing

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  Build-and-Test:
+  build:
     strategy:
       matrix:
         platform: [macos-latest, ubuntu-latest]

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,21 +9,35 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: [macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: swift build -v
-    - name: Run tests (without performance tests)
+          
+  tests:
+    runs-on: [macos-latest, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build & Run Tests (without performance tests)
       # filter regex excludes all tests targets which contain the word "Performance" in their name
-      run: swift test -v --filter="^((?!(Performance)).)*\..*$"
+      run: swift test
+           -v
+           --parallel
+           --enable-test-discovery
+           --sanitize=thread
+           --filter="^((?!(Performance)).)*\..*$"
   performance-tests:
-    runs-on: macos-latest
+    runs-on: [macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2
     - name: Build & Run Performance Tests
       # filter regex includes only test targets which contain the word "Performance" in their name
       # build with optimisation enabled
-      run: swift test --filter="^.*(Performance).*\..*" -Xswiftc="-O"
+      run: swift test
+           -Xswiftc="-O"
+           --enable-test-discovery
+           --filter="^.*(Performance).*\..*"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build-macOS:
+  test-on-macOS-and-iOS:
     strategy:
       matrix:
         platform: [macos-latest]
@@ -35,17 +35,20 @@ jobs:
         -parallel-testing-enabled
         -destination 'platform=macOS'
         
+  performance-tests-on-macOS:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
     - name: Build & Run Performance Tests on macOS
       run: >
         swift test
         -Xswiftc="-O"
         --enable-test-discovery
         --filter="^.*(Performance).*\..*"
-  build-linux:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
+    
+  test-on-linux:
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -35,7 +35,7 @@ jobs:
         --sanitize=thread
         --filter="^((?!(Performance)).)*\..*$"
         
-  tests-macOS:
+  tests-linux:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
@@ -20,6 +21,7 @@ jobs:
           
   tests:
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
@@ -37,6 +39,7 @@ jobs:
         --filter="^((?!(Performance)).)*\..*$"
   performance-tests:
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,14 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Test on macOS
-      run: >
-        xcodebuild test
-        -scheme RSocket-Package
-        -parallelizeTargets
-        -skip-testing:RSocketCorePerformanceTests
-        -parallel-testing-enabled
-        -destination 'platform=macOS'
         
     - name: Test on iOS Simulator
       run: >
@@ -31,8 +23,17 @@ jobs:
         -parallelizeTargets
         -skip-testing:RSocketCorePerformanceTests
         -parallel-testing-enabled
-        -sdk iphonesimulator
-        -destination 'platform=iOS Simulator,name=iPhone 12'
+        -sdk:iphonesimulator
+        -destination:'platform=iOS Simulator,name=iPhone 12'
+        
+    - name: Test on macOS
+      run: >
+        xcodebuild test
+        -scheme RSocket-Package
+        -parallelizeTargets
+        -skip-testing:RSocketCorePerformanceTests
+        -parallel-testing-enabled
+        -destination 'platform=macOS'
         
     - name: Build & Run Performance Tests on macOS
       run: >

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build & Run Tests (without performance tests)
       # filter regex excludes all tests targets which contain the word "Performance" in their name
-      if: runner.os == 'macOS'
       run: >
         swift test
         -v
@@ -42,7 +41,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build & Run Tests (without performance tests)
       # filter regex excludes all tests targets which contain the word "Performance" in their name
-      if: runner.os == 'macOS'
       run: >
         swift test
         -v

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,7 +20,7 @@ jobs:
         xcodebuild test
         -scheme RSocket-Package
         -parallelizeTargets
-        -skip-testing RSocketCorePerformanceTests
+        -skip-testing:RSocketCorePerformanceTests
         -parallel-testing-enabled
         -destination 'platform=macOS'
         
@@ -30,7 +30,7 @@ jobs:
         -scheme RSocket-Package
         -parallelizeTargets
         -parallel-testing-enabled
-        -skip-testing RSocketCorePerformanceTests
+        -skip-testing:RSocketCorePerformanceTests
         -sdk iphonesimulator
         -destination 'platform=iOS Simulator,name=iPhone 12'
         
@@ -39,7 +39,7 @@ jobs:
         xcodebuild test
         -scheme RSocketCore
         -configuration Release
-        -only-testing RSocketCorePerformanceTests
+        -only-testing:RSocketCorePerformanceTests
         -destination 'platform=macOS'
   build-linux:
     strategy:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,8 +8,10 @@ on:
 
 jobs:
   build:
-
-    runs-on: [macos-latest, ubuntu-latest]
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2
@@ -17,7 +19,10 @@ jobs:
       run: swift build -v
           
   tests:
-    runs-on: [macos-latest, ubuntu-latest]
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +36,10 @@ jobs:
         --sanitize=thread
         --filter="^((?!(Performance)).)*\..*$"
   performance-tests:
-    runs-on: [macos-latest, ubuntu-latest]
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+    - uses: actions/checkout@v2
     - name: Test on Linux
       if: runner.os == 'Linux'
       # filter regex excludes all tests targets which contain the word "Performance" in their name

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -23,12 +23,13 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build & Run Tests (without performance tests)
       # filter regex excludes all tests targets which contain the word "Performance" in their name
-      run: swift test
-           -v
-           --parallel
-           --enable-test-discovery
-           --sanitize=thread
-           --filter="^((?!(Performance)).)*\..*$"
+      run: >
+        swift test
+        -v
+        --parallel
+        --enable-test-discovery
+        --sanitize=thread
+        --filter="^((?!(Performance)).)*\..*$"
   performance-tests:
     runs-on: [macos-latest, ubuntu-latest]
 
@@ -37,7 +38,8 @@ jobs:
     - name: Build & Run Performance Tests
       # filter regex includes only test targets which contain the word "Performance" in their name
       # build with optimisation enabled
-      run: swift test
-           -Xswiftc="-O"
-           --enable-test-discovery
-           --filter="^.*(Performance).*\..*"
+      run: >
+        swift test
+        -Xswiftc="-O"
+        --enable-test-discovery
+        --filter="^.*(Performance).*\..*"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,38 +7,22 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [macos-latest, ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: swift build -v
-          
-  tests-macOS:
+  Build-and-Test:
     runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build & Run Tests (without performance tests)
+    - name: Test on macOS
+      if: runner.os == 'macOS'
       # filter regex excludes all tests targets which contain the word "Performance" in their name
       run: >
         swift test
-        -v
         --parallel
         --enable-test-discovery
         --sanitize=thread
         --filter="^((?!(Performance)).)*\..*$"
-  tests-iOS:
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build & Run Tests (without performance tests)
+    - name: Test on iOS Simulator
+      if: runner.os == 'macOS'
       run: >
         xcodebuild
         -scheme RSocket-Package
@@ -47,13 +31,8 @@ jobs:
         test
         -sdk iphonesimulator
         -destination 'platform=iOS Simulator,name=iPhone 12'
-        
-  tests-linux:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build & Run Tests (without performance tests)
+    - name: Test on Linux
+      if: runner.os == 'Linux''"
       # filter regex excludes all tests targets which contain the word "Performance" in their name
       run: >
         swift test
@@ -61,15 +40,6 @@ jobs:
         --parallel
         --enable-test-discovery
         --filter="^((?!(Performance)).)*\..*$"
-  performance-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [macos-latest, ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-    - uses: actions/checkout@v2
     - name: Build & Run Performance Tests
       # filter regex includes only test targets which contain the word "Performance" in their name
       # build with optimisation enabled

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -33,6 +33,20 @@ jobs:
         --enable-test-discovery
         --sanitize=thread
         --filter="^((?!(Performance)).)*\..*$"
+  tests-iOS:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build & Run Tests (without performance tests)
+      run: >
+        xcodebuild
+        -scheme RSocket-Package
+        -parallelizeTargets
+        -skip-testing RSocketCodePerformanceTests
+        test
+        -sdk iphonesimulator
+        -destination 'platform=iOS Simulator,name=iPhone 12'
         
   tests-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -43,7 +43,7 @@ jobs:
         xcodebuild
         -scheme RSocket-Package
         -parallelizeTargets
-        -skip-testing RSocketCodePerformanceTests
+        -skip-testing RSocketCorePerformanceTests
         test
         -sdk iphonesimulator
         -destination 'platform=iOS Simulator,name=iPhone 12'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,19 +19,20 @@ jobs:
       if: runner.os == 'macOS'
       # filter regex excludes all tests targets which contain the word "Performance" in their name
       run: >
-        swift test
-        --parallel
-        --enable-test-discovery
-        --sanitize=thread
-        --filter="^((?!(Performance)).)*\..*$"
-    - name: Test on iOS Simulator
-      if: runner.os == 'macOS'
-      run: >
-        xcodebuild
+        xcodebuild test
         -scheme RSocket-Package
         -parallelizeTargets
         -skip-testing RSocketCorePerformanceTests
-        test
+        -parallel-testing-enabled
+        -destination 'platform=macOS'
+    - name: Test on iOS Simulator
+      if: runner.os == 'macOS'
+      run: >
+        xcodebuild test
+        -scheme RSocket-Package
+        -parallelizeTargets
+        -parallel-testing-enabled
+        -skip-testing RSocketCorePerformanceTests
         -sdk iphonesimulator
         -destination 'platform=iOS Simulator,name=iPhone 12'
     - name: Test on Linux

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -35,7 +35,7 @@ jobs:
         -sdk iphonesimulator
         -destination 'platform=iOS Simulator,name=iPhone 12'
     - name: Test on Linux
-      if: runner.os == 'Linux''"
+      if: runner.os == 'Linux'
       # filter regex excludes all tests targets which contain the word "Performance" in their name
       run: >
         swift test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-macOS:
     strategy:
       matrix:
         platform: [macos-latest]
@@ -41,7 +41,7 @@ jobs:
         -configuration Release
         -only-testing RSocketCorePerformanceTests
         -destination 'platform=macOS'
-  build:
+  build-linux:
     strategy:
       matrix:
         platform: [ubuntu-latest]

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   Build-and-Test:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        platform: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,14 +10,12 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [macos-latest, ubuntu-latest]
+        platform: [macos-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2
     - name: Test on macOS
-      if: runner.os == 'macOS'
-      # filter regex excludes all tests targets which contain the word "Performance" in their name
       run: >
         xcodebuild test
         -scheme RSocket-Package
@@ -25,8 +23,8 @@ jobs:
         -skip-testing RSocketCorePerformanceTests
         -parallel-testing-enabled
         -destination 'platform=macOS'
+        
     - name: Test on iOS Simulator
-      if: runner.os == 'macOS'
       run: >
         xcodebuild test
         -scheme RSocket-Package
@@ -35,6 +33,21 @@ jobs:
         -skip-testing RSocketCorePerformanceTests
         -sdk iphonesimulator
         -destination 'platform=iOS Simulator,name=iPhone 12'
+        
+    - name: Build & Run Performance Tests on macOS
+      run: >
+        xcodebuild test
+        -scheme RSocketCore
+        -configuration Release
+        -only-testing RSocketCorePerformanceTests
+        -destination 'platform=macOS'
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
     - name: Test on Linux
       if: runner.os == 'Linux'
       # filter regex excludes all tests targets which contain the word "Performance" in their name
@@ -44,9 +57,9 @@ jobs:
         --parallel
         --enable-test-discovery
         --filter="^((?!(Performance)).)*\..*$"
-    - name: Build & Run Performance Tests
-      # filter regex includes only test targets which contain the word "Performance" in their name
-      # build with optimisation enabled
+        
+    - name: Build & Run Performance Tests on Linux
+      if: runner.os == 'Linux'
       run: >
         swift test
         -Xswiftc="-O"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,10 +8,7 @@ on:
 
 jobs:
   test-on-macOS-and-iOS:
-    strategy:
-      matrix:
-        platform: [macos-latest]
-    runs-on: ${{ matrix.platform }}
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -53,7 +50,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Test on Linux
-      if: runner.os == 'Linux'
       # filter regex excludes all tests targets which contain the word "Performance" in their name
       run: >
         swift test
@@ -62,7 +58,6 @@ jobs:
         --filter="^((?!(Performance)).)*\..*$"
         
     - name: Build & Run Performance Tests on Linux
-      if: runner.os == 'Linux'
       run: >
         swift test
         -Xswiftc="-O"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,23 +19,35 @@ jobs:
     - name: Build
       run: swift build -v
           
-  tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.platform }}
+  tests-macOS:
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2
     - name: Build & Run Tests (without performance tests)
       # filter regex excludes all tests targets which contain the word "Performance" in their name
+      if: runner.os == 'macOS'
       run: >
         swift test
         -v
         --parallel
         --enable-test-discovery
         --sanitize=thread
+        --filter="^((?!(Performance)).)*\..*$"
+        
+  tests-macOS:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build & Run Tests (without performance tests)
+      # filter regex excludes all tests targets which contain the word "Performance" in their name
+      if: runner.os == 'macOS'
+      run: >
+        swift test
+        -v
+        --parallel
+        --enable-test-discovery
         --filter="^((?!(Performance)).)*\..*$"
   performance-tests:
     strategy:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -37,11 +37,10 @@ jobs:
         
     - name: Build & Run Performance Tests on macOS
       run: >
-        xcodebuild test
-        -scheme RSocketCore
-        -configuration Release
-        -only-testing:RSocketCorePerformanceTests
-        -destination 'platform=macOS'
+        swift test
+        -Xswiftc="-O"
+        --enable-test-discovery
+        --filter="^.*(Performance).*\..*"
   build-linux:
     strategy:
       matrix:
@@ -55,7 +54,6 @@ jobs:
       # filter regex excludes all tests targets which contain the word "Performance" in their name
       run: >
         swift test
-        -v
         --parallel
         --enable-test-discovery
         --filter="^((?!(Performance)).)*\..*$"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,8 +29,8 @@ jobs:
         xcodebuild test
         -scheme RSocket-Package
         -parallelizeTargets
-        -parallel-testing-enabled
         -skip-testing:RSocketCorePerformanceTests
+        -parallel-testing-enabled
         -sdk iphonesimulator
         -destination 'platform=iOS Simulator,name=iPhone 12'
         

--- a/Sources/UserCode/UserCode.swift
+++ b/Sources/UserCode/UserCode.swift
@@ -1,3 +1,4 @@
+#if canImport(Network)
 import Network
 import ReactiveSwift
 import RSocketTSChannel
@@ -19,3 +20,4 @@ func t() {
 
     let streamProducer: SignalProducer<Payload, Swift.Error> = client.producer.skipNil().flatMap(.latest) { $0.requester.requestStream(payload: .empty) }
 }
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,1 @@
+fatalError("Run tests with `swift test --enable-test-discovery`.")


### PR DESCRIPTION
improve CI Testing

### Motivation:
Make sure RSocket does work on iOS & Linux too.

### Modifications:

- build & run tests on Ubuntu
- run tests on iOS
- enable thread sanitizer for iOS & macOS
- build in parallel
- run tests in parallel (except performance tests)
- use xcodebuild to build & run tests on macOS

### Result:
Tests now run on iOS and Linux too and should be slightly faster because of parallel building and testing 

### Discussion 
#### Thread Sanitizer on Linux
On Linux, the test fail with thread sanitizer enabled. [Thread santizer support on linux is new for swift](https://swift.org/blog/tsan-support-on-linux/) and I think there is still a bug in it. 
For Example, `RequestResponseTerminationBehaviourTests.testRequesterSendsCancel` fails but it just calls a pure function and does not mutate any state. I don't have a working linux environment to debug this issue further so I would just leave thread sanitizer disabled for now. It is still enabled on macOS.
 

<details>
  <summary>
Thread Sanitizer Error for RequestResponseTerminationBehaviourTests.testRequesterSendsCancel
 </summary>



```
Test Suite 'Selected tests' started at 2021-03-18 18:21:43.116
584
Test Suite 'RequestResponseTerminationBehaviourTests' started at 2021-03-18 18:21:43.129
585
Test Case 'RequestResponseTerminationBehaviourTests.testRequesterSendsCancel' started at 2021-03-18 18:21:43.129
586
ThreadSanitizer:DEADLYSIGNAL
587
==2562==ERROR: ThreadSanitizer: SEGV on unknown address 0x07fda4cff260 (pc 0x55ff68f291a5 bp 0x7c0000000000 sp 0x7ffc48ae00b8 T2562)
588
==2562==The signal is caused by a WRITE memory access.
589
    #0 __tsan::MemoryAccess(__tsan::ThreadState*, unsigned long, unsigned long, int, bool, bool) /home/build-user/llvm-project/compiler-rt/lib/tsan/../sanitizer_common/sanitizer_atomic_clang_x86.h:81 (RSocketPackageTests.xctest+0x1071a5)
590
    #1 StoreShadow /home/build-user/llvm-project/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp:613 (RSocketPackageTests.xctest+0x1071a5)
591
    #2 MemoryAccessImpl1 /home/build-user/llvm-project/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp:701 (RSocketPackageTests.xctest+0x1071a5)
592
    #3 MemoryAccess /home/build-user/llvm-project/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp:878 (RSocketPackageTests.xctest+0x1071a5)
593
    #4 __tsan::ExternalAccess(void*, void*, void*, void (*)(__tsan::ThreadState*, unsigned long, unsigned long, int)) /home/build-user/llvm-project/compiler-rt/lib/tsan/rtl/tsan_external.cpp:67 (RSocketPackageTests.xctest+0xa01dc)
594
    #5 $s16RSocketCoreTests035RequestResponseTerminationBehaviourC0C24testRequesterSendsCancelyyFSbyKXEfu_ /home/runner/work/rsocket-swift/rsocket-swift/<compiler-generated>:? (RSocketPackageTests.xctest+0x51dc27)
595
    #6 $s16RSocketCoreTests035RequestResponseTerminationBehaviourC0C24testRequesterSendsCancelyyFSbyKXEfu_TA TerminationBehaviourTests.swift.o:? (RSocketPackageTests.xctest+0x51dc97)
596
    #7 $s6XCTest13XCTAssertTrue__4file4lineySbyKXK_SSyXKs12StaticStringVSutF ??:? (libXCTest.so+0x3d8a5)
597
    #8 $s16RSocketCoreTests035RequestResponseTerminationBehaviourC0C24testRequesterSendsCancelyyF /home/runner/work/rsocket-swift/rsocket-swift/Tests/RSocketCoreTests/TerminationBehaviourTests.swift:27 (RSocketPackageTests.xctest+0x51dbbf)
598
    #9 $s16RSocketCoreTests035RequestResponseTerminationBehaviourC0C0a7PackageC0E05__allc2__defgC033_A8597678E06260891431B4EF4ED59470LLSaySS_yycACctGvpZfiyycACcfu_yycfu0_ /home/runner/work/rsocket-swift/rsocket-swift/.build/x86_64-unknown-linux-gnu/debug/RSocketPackageTestsTestlist.derived/RSocketCoreTests.swift:33 (RSocketPackageTests.xctest+0x526ccd)
599
    #10 $s16RSocketCoreTests035RequestResponseTerminationBehaviourC0C0a7PackageC0E05__allc2__defgC033_A8597678E06260891431B4EF4ED59470LLSaySS_yycACctGvpZfiyycACcfu_yycfu0_TA RSocketCoreTests.swift.o:? (RSocketPackageTests.xctest+0x52b9cd)
600
    #11 $sIeg_ytIegr_TR crtstuff.c:? (RSocketPackageTests.xctest+0x33d6b7)
601
    #12 $sIeg_ytIegr_TRTA.109 RSocketCoreTests.swift.o:? (RSocketPackageTests.xctest+0x52b98d)
602
    #13 $sytIegr_Ieg_TRTA XCTestCase.swift.o:? (libXCTest.so+0x37a20)
603
    #14 $s6XCTest4test33_3BE257A46ADB477C7BF2D39968B39F9DLLyyAA0A4CaseCKcyyKcxcAERbzlFyAEKcfU_TA XCTestCase.swift.o:? (libXCTest.so+0x37a8b)
604
    #15 $s6XCTest0A4CaseCs5Error_pIeggzo_ACytsAD_pIegnrzo_TRTA XCTestCase.swift.o:? (libXCTest.so+0x37a03)
605
    #16 $s6XCTest0A4CaseCyts5Error_pIegnrzo_ACsAD_pIeggzo_TRTA XCTestCaseSuite.swift.o:? (libXCTest.so+0x28576)
606
    #17 $s6XCTest0A4CaseC10invokeTestyyF ??:? (libXCTest.so+0x363b6)
607
    #18 $s6XCTest0A4CaseC7performyyAA0A3RunCF ??:? (libXCTest.so+0x36105)
608
    #19 $s6XCTestAAC3runyyF ??:? (libXCTest.so+0x39de5)
609
    #20 $s6XCTest0A5SuiteC7performyyAA0A3RunCF ??:? (libXCTest.so+0x3803f)
610
    #21 $s6XCTestAAC3runyyF ??:? (libXCTest.so+0x39de5)
611
    #22 $s6XCTest0A5SuiteC7performyyAA0A3RunCF ??:? (libXCTest.so+0x3803f)
612
    #23 $s6XCTestAAC3runyyF ??:? (libXCTest.so+0x39de5)
613
    #24 $s6XCTest7XCTMain_9argumentss5NeverOSayAA0A4CaseCm04testE5Class_SaySS_yAGKctG8allTeststG_SaySSGtF ??:? (libXCTest.so+0x34b19)
614
    #25 $s6XCTest7XCTMainys5NeverOSayAA0A4CaseCm04testD5Class_SaySS_yAFKctG8allTeststGF ??:? (libXCTest.so+0x34548)
615
    #26 main /home/runner/work/rsocket-swift/rsocket-swift/.build/x86_64-unknown-linux-gnu/debug/RSocketPackageTestsTestlist.derived/main.swift:8 (RSocketPackageTests.xctest+0x52c9f4)
616
    #27 __libc_start_main ??:? (libc.so.6+0x270b2)
617
    #28 _start ??:? (RSocketPackageTests.xctest+0x7cd5d)
618

619
ThreadSanitizer can not provide additional info.
620
SUMMARY: ThreadSanitizer: SEGV /home/build-user/llvm-project/compiler-rt/lib/tsan/../sanitizer_common/sanitizer_atomic_clang_x86.h:81 in atomic_store<__sanitizer::atomic_uint64_t>
621
==2562==ABORTING
```
</details>

#### xcodebuild vs. SwiftPM
- xcodebuild is not available on Linux
- SwiftPM does not yet support running tests on iOS. We need to use xcodebuild for that.
- SwiftPM and xcodebuild do not share any caches and will refetch and rebuild all dependencies which should be avoided.
- Performance Tests are tricky:
  - Both SwiftPM and xcodebuild do support a filter option which lets us run only a subset of the tests. 
  - SwiftPM only builds test targets which are needed
  - xcodebuild builds everything (or tries to)
    - normal tests in debug mode are no problem
    - performance tests need to be build in release configuration. In release mode, `@testable import` is not supported but used in most tests targets and all but `RSocketCorePerformanceTests` fail to build

Because of the reasons above, I have decided to use xcodebuild to build & run tests for macOS & iOS but run performance tests using SwiftPM.
On Linux there was really no choice but to use SwiftPM.