### PR TITLE
adds tests that use Network.Framework

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -27,6 +27,15 @@
           "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
           "version": "1.8.0"
         }
+      },
+      {
+        "package": "swift-nio-transport-services",
+        "repositoryURL": "https://github.com/apple/swift-nio-transport-services",
+        "state": {
+          "branch": null,
+          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
+          "version": "1.9.2"
+        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     name: "RSocket",
     platforms: [
         .macOS(.v10_15),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,6 @@ let package = Package(
     name: "RSocket",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],
@@ -19,6 +18,7 @@ let package = Package(
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.5.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.26.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.8.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services", from: "1.9.2"),
     ],
     targets: [
         .target(name: "RSocketCore", dependencies: [
@@ -34,11 +34,13 @@ let package = Package(
             "RSocketCore",
             "RSocketTestUtilities",
             .product(name: "NIOExtras", package: "swift-nio-extras"),
+            .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
         ]),
         .testTarget(name: "RSocketCorePerformanceTests", dependencies: [
             "RSocketCore",
             "RSocketTestUtilities",
             .product(name: "NIOExtras", package: "swift-nio-extras"),
+            .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
         ]),
         .testTarget(name: "RSocketCombineTests", dependencies: ["RSocketCombine"]),
         .testTarget(name: "RSocketReactiveSwiftTests", dependencies: ["RSocketReactiveSwift"]),

--- a/Tests/RSocketCorePerformanceTests/NetworkFrameworkEndToEndTests.swift
+++ b/Tests/RSocketCorePerformanceTests/NetworkFrameworkEndToEndTests.swift
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(Network)
+import XCTest
+import NIO
+import NIOExtras
+import RSocketCore
+import RSocketTestUtilities
+import NIOTransportServices
+
+extension NIOTSListenerBootstrap: NIOServerTCPBootstrapProtocol{}
+
+final class NetworkFrameworkEndToEndTests: EndToEndTests {
+    private var clientEventLoopGroup: NIOTSEventLoopGroup!
+    private var serverEventLoopGroup: NIOTSEventLoopGroup!
+    override func setUp() {
+        clientEventLoopGroup = NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .userInteractive)
+        serverEventLoopGroup = NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .userInteractive)
+    }
+    override func tearDownWithError() throws {
+        try clientEventLoopGroup.syncShutdownGracefully()
+        try serverEventLoopGroup.syncShutdownGracefully()
+    }
+    
+    override func makeServerBootstrap(
+        responderSocket: RSocket = TestRSocket(),
+        shouldAcceptClient: ClientAcceptorCallback? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> NIOServerTCPBootstrapProtocol {
+        NIOTSListenerBootstrap(group: serverEventLoopGroup)
+            .childChannelInitializer { (channel) -> EventLoopFuture<Void> in
+                channel.pipeline.addHandlers([
+                    ByteToMessageHandler(LengthFieldBasedFrameDecoder(lengthFieldBitLength: .threeBytes)),
+                    LengthFieldPrepender(lengthFieldBitLength: .threeBytes),
+                ]).flatMap {
+                    channel.pipeline.addRSocketServerHandlers(
+                        shouldAcceptClient: shouldAcceptClient,
+                        makeResponder: { _ in responderSocket }
+                    )
+                }
+            }
+    }
+    override func makeClientBootstrap(
+        responderSocket: RSocket = TestRSocket(),
+        config: ClientSetupConfig = EndToEndTests.defaultClientSetup,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> NIOClientTCPBootstrapProtocol {
+        NIOTSConnectionBootstrap(group: clientEventLoopGroup)
+            .channelInitializer { (channel) -> EventLoopFuture<Void> in
+                channel.pipeline.addHandlers([
+                    ByteToMessageHandler(LengthFieldBasedFrameDecoder(lengthFieldBitLength: .threeBytes)),
+                    LengthFieldPrepender(lengthFieldBitLength: .threeBytes),
+                ]).flatMap {
+                    channel.pipeline.addRSocketClientHandlers(config: config, responder: responderSocket)
+                }
+            }
+    }
+}
+#endif

--- a/Tests/RSocketCoreTests/EndToEndTests.swift
+++ b/Tests/RSocketCoreTests/EndToEndTests.swift
@@ -20,27 +20,45 @@ import NIOExtras
 import RSocketCore
 import RSocketTestUtilities
 
-final class EndToEndTests: XCTestCase {
-    private static let defaultClientSetup = ClientSetupConfig(
+protocol NIOServerTCPBootstrapProtocol {
+    /// Bind the `ServerSocketChannel` to `host` and `port`.
+    ///
+    /// - parameters:
+    ///     - host: The host to bind on.
+    ///     - port: The port to bind on.
+    func bind(host: String, port: Int) -> EventLoopFuture<Channel>
+}
+
+extension ServerBootstrap: NIOServerTCPBootstrapProtocol{}
+
+class EndToEndTests: XCTestCase {
+    static let defaultClientSetup = ClientSetupConfig(
         timeBetweenKeepaliveFrames: 500,
         maxLifetime: 5000,
         metadataEncodingMimeType: "utf8",
         dataEncodingMimeType: "utf8"
     )
-    let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-    override func tearDownWithError() throws {
-        try eventLoopGroup.syncShutdownGracefully()
-    }
     
     let host = "127.0.0.1"
+    
+    private var clientEventLoopGroup: MultiThreadedEventLoopGroup!
+    private var serverEventLoopGroup: MultiThreadedEventLoopGroup!
+    override func setUp() {
+        clientEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        serverEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    }
+    override func tearDownWithError() throws {
+        try clientEventLoopGroup.syncShutdownGracefully()
+        try serverEventLoopGroup.syncShutdownGracefully()
+    }
     
     func makeServerBootstrap(
         responderSocket: RSocket = TestRSocket(),
         shouldAcceptClient: ClientAcceptorCallback? = nil,
         file: StaticString = #file,
         line: UInt = #line
-    ) -> ServerBootstrap {
-        return ServerBootstrap(group: eventLoopGroup)
+    ) -> NIOServerTCPBootstrapProtocol {
+        return ServerBootstrap(group: serverEventLoopGroup)
             .childChannelInitializer { (channel) -> EventLoopFuture<Void> in
                 channel.pipeline.addHandlers([
                     ByteToMessageHandler(LengthFieldBasedFrameDecoder(lengthFieldBitLength: .threeBytes)),
@@ -59,8 +77,8 @@ final class EndToEndTests: XCTestCase {
         config: ClientSetupConfig = EndToEndTests.defaultClientSetup,
         file: StaticString = #file,
         line: UInt = #line
-    ) -> ClientBootstrap {
-        return ClientBootstrap(group: eventLoopGroup)
+    ) -> NIOClientTCPBootstrapProtocol {
+        return ClientBootstrap(group: clientEventLoopGroup)
             .channelInitializer { (channel) -> EventLoopFuture<Void> in
                 channel.pipeline.addHandlers([
                     ByteToMessageHandler(LengthFieldBasedFrameDecoder(lengthFieldBitLength: .threeBytes)),

--- a/Tests/RSocketCoreTests/NetworkFrameworkEndToEndTests.swift
+++ b/Tests/RSocketCoreTests/NetworkFrameworkEndToEndTests.swift
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(Network)
+import XCTest
+import NIO
+import NIOExtras
+import RSocketCore
+import RSocketTestUtilities
+import NIOTransportServices
+
+extension NIOTSListenerBootstrap: NIOServerTCPBootstrapProtocol{}
+
+final class NetworkFrameworkEndToEndTests: EndToEndTests {
+    private var clientEventLoopGroup: NIOTSEventLoopGroup!
+    private var serverEventLoopGroup: NIOTSEventLoopGroup!
+    override func setUp() {
+        clientEventLoopGroup = NIOTSEventLoopGroup()
+        serverEventLoopGroup = NIOTSEventLoopGroup()
+    }
+    override func tearDownWithError() throws {
+        try clientEventLoopGroup.syncShutdownGracefully()
+        try serverEventLoopGroup.syncShutdownGracefully()
+    }
+    
+    override func makeServerBootstrap(
+        responderSocket: RSocket = TestRSocket(),
+        shouldAcceptClient: ClientAcceptorCallback? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> NIOServerTCPBootstrapProtocol {
+        NIOTSListenerBootstrap(group: serverEventLoopGroup)
+            // Specify backlog and enable SO_REUSEADDR for the server itself
+            .childChannelInitializer { (channel) -> EventLoopFuture<Void> in
+                channel.pipeline.addHandlers([
+                    ByteToMessageHandler(LengthFieldBasedFrameDecoder(lengthFieldBitLength: .threeBytes)),
+                    LengthFieldPrepender(lengthFieldBitLength: .threeBytes),
+                ]).flatMap {
+                    channel.pipeline.addRSocketServerHandlers(
+                        shouldAcceptClient: shouldAcceptClient,
+                        makeResponder: { _ in responderSocket }
+                    )
+                }
+            }
+    }
+    override func makeClientBootstrap(
+        responderSocket: RSocket = TestRSocket(),
+        config: ClientSetupConfig = EndToEndTests.defaultClientSetup,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> NIOClientTCPBootstrapProtocol {
+        NIOTSConnectionBootstrap(group: clientEventLoopGroup)
+            .channelInitializer { (channel) -> EventLoopFuture<Void> in
+                channel.pipeline.addHandlers([
+                    ByteToMessageHandler(LengthFieldBasedFrameDecoder(lengthFieldBitLength: .threeBytes)),
+                    LengthFieldPrepender(lengthFieldBitLength: .threeBytes),
+                ]).flatMap {
+                    channel.pipeline.addRSocketClientHandlers(config: config, responder: responderSocket)
+                }
+            }
+    }
+}
+#endif

--- a/Tests/RSocketCoreTests/NetworkFrameworkEndToEndTests.swift
+++ b/Tests/RSocketCoreTests/NetworkFrameworkEndToEndTests.swift
@@ -43,7 +43,6 @@ final class NetworkFrameworkEndToEndTests: EndToEndTests {
         line: UInt = #line
     ) -> NIOServerTCPBootstrapProtocol {
         NIOTSListenerBootstrap(group: serverEventLoopGroup)
-            // Specify backlog and enable SO_REUSEADDR for the server itself
             .childChannelInitializer { (channel) -> EventLoopFuture<Void> in
                 channel.pipeline.addHandlers([
                     ByteToMessageHandler(LengthFieldBasedFrameDecoder(lengthFieldBitLength: .threeBytes)),


### PR DESCRIPTION
Add tests which uses Network.framework instead of Berkeley Sockets as the underlying channel implementation.

### Motivation:
Measure Performance of Network.Framework and see if it generally works.

### Modifications:
- Add class NetworkFrameEndToEndTests which subclasses EndToEndTests
- overwrite `setupClient` and `setupSever` to bootstrap Network.Framework 
- performance tests now limit parallelism (e.g. concurrent requests in flight) to better model real world usage

### Result:
End-to-End & Performance tests do now use Network.Framework as well

#### Performance Tests Results:
- **macOS**: Network.Framework is **~3x slower** than Berkeley Sockets
- **iOS**: Swift Packages do not support running tests on real iOS device, only on simulator where performance tests are not meaningful
- **Linux**: Network.Framework is not available on Linux
