### PR TITLE
adds fragmentation tests

### DIFF
--- a/Sources/RSocketCore/Streams/Defragmentation/FragmentedFrameAssembler.swift
+++ b/Sources/RSocketCore/Streams/Defragmentation/FragmentedFrameAssembler.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-internal enum FragmentationResult {
+internal enum FragmentationResult: Equatable {
     case complete(Frame)
     case incomplete
     case error(reason: String)

--- a/Sources/RSocketTestUtilities/Payload.swift
+++ b/Sources/RSocketTestUtilities/Payload.swift
@@ -17,11 +17,24 @@
 import RSocketCore
 import Foundation
 
+extension Payload {
+    /// used to create payload with the given strings as a UTF-8 encoded data and metadata
+    /// - Parameter metadata: string that is encoded as UTF-8 and put into the metadata segment of the payload
+    /// - Parameter data: string that is encoded as UTF-8 and put into the data segment of the payload
+    public init(metadata: String? = nil, data: String) {
+        self.init(metadata: metadata.map{ Data($0.utf8) }, data: Data(data.utf8))
+    }
+    
+    /// combined size of metadata and data.
+    /// - Note: this does not include the extra 3 bytes which is needed to encode the metadata length in some frames
+    public var size: Int32 { Int32((metadata?.count ?? 0) + data.count) }
+}
+
 extension Payload: ExpressibleByStringLiteral {
     /// used to create payload with the given string as a UTF-8 encoded data and no metadata
     /// - Parameter value: string that is encoded as UTF-8 and put into the data segment of the payload
     public init(stringLiteral value: String) {
-        self.init(data: Data(value.utf8))
+        self.init(data: value)
     }
 }
 

--- a/Tests/RSocketCoreTests/FragmentationTests.swift
+++ b/Tests/RSocketCoreTests/FragmentationTests.swift
@@ -31,18 +31,26 @@ extension FragmentedFrameAssembler {
     }
 }
 
+fileprivate extension Payload {
+    init(metadata: String, data: String) {
+        self.init(metadata: Data(metadata.utf8), data: Data(data.utf8))
+    }
+    var size: Int32 { Int32((metadata?.count ?? 0) + data.count) }
+}
+
 final class FragmentationTests: XCTestCase {
     private let frameHeaderSize: Int32 = 6
+    private let frameHeaderSizeWithMetadata: Int32 = 6 + 3
     
     // MARK: Payload without Metadata
     func testDoNotSplitPayloadIfItFitsExactlyIntoOneFrame() {
         let payload: Payload = """
         Payload without metadata which is not too large to fit into a single frame
         """
-        XCTAssertEqual(payload.data.count, 74)
+        XCTAssertEqual(payload.size, 74)
         let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
         let fragments = frame.splitIntoFragmentsIfNeeded(
-            maximumFrameSize: Int32(payload.data.count) + frameHeaderSize
+            maximumFrameSize: payload.size + frameHeaderSize
         )
         XCTAssertEqual(fragments.count, 1)
         
@@ -53,10 +61,10 @@ final class FragmentationTests: XCTestCase {
         let payload: Payload = """
         Payload without metadata which is too large to fit into a single frame
         """
-        XCTAssertEqual(payload.data.count, 70)
+        XCTAssertEqual(payload.size, 70)
         let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
         let fragments = frame.splitIntoFragmentsIfNeeded(
-            maximumFrameSize: Int32(payload.data.count) - 1 + frameHeaderSize
+            maximumFrameSize: payload.size - 1 + frameHeaderSize
         )
         XCTAssertEqual(fragments.count, 2)
         
@@ -68,7 +76,7 @@ final class FragmentationTests: XCTestCase {
         let payload: Payload = """
         Payload without metadata which is too large to fit into a single frame
         """
-        XCTAssertEqual(payload.data.count, 70)
+        XCTAssertEqual(payload.size, 70)
         XCTAssertTrue(
             payload.data.count.isMultiple(of: 2),
             "size of payload needs to be a multiple of two, otherwise it can't fit perfectly into two frames"
@@ -87,13 +95,98 @@ final class FragmentationTests: XCTestCase {
         let payload: Payload = """
         Payload without metadata which is too large to fit into a single frame!
         """
-        XCTAssertEqual(payload.data.count, 71)
+        XCTAssertEqual(payload.size, 71)
         let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
         let fragments = frame.splitIntoFragmentsIfNeeded(
             maximumFrameSize: 35 + frameHeaderSize
         )
         XCTAssertEqual(fragments.count, 3)
         
+        var assembler = FragmentedFrameAssembler()
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .incomplete)
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 1]), .incomplete)
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 2]), .complete(frame))
+    }
+    
+    // MARK: Payload with Metadata
+    func testDoNotSplitPayloadWithMetadataIfItFitsExactlyIntoOneFrame() {
+        let payload = Payload(
+            metadata: "Some Metadata",
+            data: "Payload with metadata which is not too large to fit into a single frame"
+        )
+        XCTAssertEqual(payload.size, 84)
+        let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
+        let fragments = frame.splitIntoFragmentsIfNeeded(
+            maximumFrameSize: payload.size + frameHeaderSizeWithMetadata
+        )
+        XCTAssertEqual(fragments.count, 1)
+
+        var assembler = FragmentedFrameAssembler()
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .complete(frame))
+    }
+    func testSplitPayloadWithMetadataIfPayloadIsOneByteTooBig() {
+        let payload = Payload(
+            metadata: "Some Metadata",
+            data: "Payload with metadata which is too large to fit into a single frame"
+        )
+        XCTAssertEqual(payload.size, 80)
+        let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
+        let fragments = frame.splitIntoFragmentsIfNeeded(
+            maximumFrameSize: payload.size - 1 + frameHeaderSizeWithMetadata
+        )
+        XCTAssertEqual(fragments.count, 2)
+
+        var assembler = FragmentedFrameAssembler()
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .incomplete)
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 1]), .complete(frame))
+    }
+    func testSplitPayloadWithMetadataIntoTwoFragmentsIfItFitsExactlyIntoTwoFrames() {
+        let payload = Payload(
+            metadata: "Some Metadata",
+            data: "Payload with metadata which is too large to fit into a single frame 3b"
+        )
+        XCTAssertEqual(
+            payload.size, 80 + 3,
+            """
+            First fragment should include payload and metadata but second only payload.
+            Because the first fragments header needs to include the length of the metadata,
+            it is 3 bytes larger than the second fragment.
+            Because of this difference, we add 3 bytes to the end of the payload to fills the last fragment completely
+            """
+        )
+        
+        let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
+        let fragments = frame.splitIntoFragmentsIfNeeded(
+            maximumFrameSize: 40 + frameHeaderSizeWithMetadata
+        )
+        XCTAssertEqual(fragments.count, 2)
+
+        var assembler = FragmentedFrameAssembler()
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .incomplete)
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 1]), .complete(frame))
+    }
+    func testSplitPayloadWithMetadataIntoThreeFragmentsIfItIsOneByteTooLarge() {
+        let payload = Payload(
+            metadata: "Some Metadata",
+            data: "Payload with metadata which is too large to fit into a single frame 3b1"
+        )
+        XCTAssertEqual(
+            payload.size, 80 + 3 + 1,
+            """
+            First fragment should include payload and metadata but second only payload.
+            Because the first fragments header needs to include the length of the metadata,
+            it is 3 bytes larger than the second fragment.
+            Because of this difference, we add 3 bytes to the end of the payload to fills the last fragment completely.
+            To overflow the second fragment, we add an additional byte.
+            """
+        )
+        
+        let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
+        let fragments = frame.splitIntoFragmentsIfNeeded(
+            maximumFrameSize: 40 + frameHeaderSizeWithMetadata
+        )
+        XCTAssertEqual(fragments.count, 3)
+
         var assembler = FragmentedFrameAssembler()
         XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .incomplete)
         XCTAssertEqual(assembler.process(frame: fragments[safe: 1]), .incomplete)

--- a/Tests/RSocketCoreTests/FragmentationTests.swift
+++ b/Tests/RSocketCoreTests/FragmentationTests.swift
@@ -173,10 +173,10 @@ final class FragmentationTests: XCTestCase {
         XCTAssertEqual(
             payload.size, 80 + 3 + 1,
             """
-            First fragment should include payload and metadata but second only payload.
+            First fragment should include payload and metadata but the second fragment only data.
             Because the first fragments header needs to include the length of the metadata,
             it is 3 bytes larger than the second fragment.
-            Because of this difference, we add 3 bytes to the end of the payload to fills the last fragment completely.
+            We add 3 bytes to the end of the payload to fills the last fragment completely.
             To overflow the second fragment, we add an additional byte.
             """
         )

--- a/Tests/RSocketCoreTests/FragmentationTests.swift
+++ b/Tests/RSocketCoreTests/FragmentationTests.swift
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import RSocketTestUtilities
+@testable import RSocketCore
+
+extension RandomAccessCollection {
+    public subscript(safe index: Index) -> Element? {
+        guard self.indices.contains(index) else { return nil }
+        return self[index]
+    }
+}
+
+extension FragmentedFrameAssembler {
+    mutating func process(frame: Frame?) -> FragmentationResult? {
+        frame.map({ process(frame: $0) })
+    }
+}
+
+final class FragmentationTests: XCTestCase {
+    private let frameHeaderSize: Int32 = 6
+    
+    // MARK: Payload without Metadata
+    func testDoNotSplitPayloadIfItFitsExactlyIntoOneFrame() {
+        let payload: Payload = """
+        Payload without metadata which is not too large to fit into a single frame
+        """
+        XCTAssertEqual(payload.data.count, 74)
+        let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
+        let fragments = frame.splitIntoFragmentsIfNeeded(
+            maximumFrameSize: Int32(payload.data.count) + frameHeaderSize
+        )
+        XCTAssertEqual(fragments.count, 1)
+        
+        var assembler = FragmentedFrameAssembler()
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .complete(frame))
+    }
+    func testSplitPayloadIfPayloadIsOneByteTooBig() {
+        let payload: Payload = """
+        Payload without metadata which is too large to fit into a single frame
+        """
+        XCTAssertEqual(payload.data.count, 70)
+        let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
+        let fragments = frame.splitIntoFragmentsIfNeeded(
+            maximumFrameSize: Int32(payload.data.count) - 1 + frameHeaderSize
+        )
+        XCTAssertEqual(fragments.count, 2)
+        
+        var assembler = FragmentedFrameAssembler()
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .incomplete)
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 1]), .complete(frame))
+    }
+    func testSplitPayloadIntoTwoFragmentsIfItFitsExactlyIntoTwoFrames() {
+        let payload: Payload = """
+        Payload without metadata which is too large to fit into a single frame
+        """
+        XCTAssertEqual(payload.data.count, 70)
+        XCTAssertTrue(
+            payload.data.count.isMultiple(of: 2),
+            "size of payload needs to be a multiple of two, otherwise it can't fit perfectly into two frames"
+        )
+        let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
+        let fragments = frame.splitIntoFragmentsIfNeeded(
+            maximumFrameSize: 35 + frameHeaderSize
+        )
+        XCTAssertEqual(fragments.count, 2)
+        
+        var assembler = FragmentedFrameAssembler()
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .incomplete)
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 1]), .complete(frame))
+    }
+    func testSplitPayloadIntoThreeFragmentsIfItIsOneByteTooLarge() {
+        let payload: Payload = """
+        Payload without metadata which is too large to fit into a single frame!
+        """
+        XCTAssertEqual(payload.data.count, 71)
+        let frame = PayloadFrameBody(isCompletion: false, isNext: true, payload: payload).asFrame(withStreamId: 7)
+        let fragments = frame.splitIntoFragmentsIfNeeded(
+            maximumFrameSize: 35 + frameHeaderSize
+        )
+        XCTAssertEqual(fragments.count, 3)
+        
+        var assembler = FragmentedFrameAssembler()
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .incomplete)
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 1]), .incomplete)
+        XCTAssertEqual(assembler.process(frame: fragments[safe: 2]), .complete(frame))
+    }
+}

--- a/Tests/RSocketCoreTests/PayloadFragmentationTests.swift
+++ b/Tests/RSocketCoreTests/PayloadFragmentationTests.swift
@@ -19,26 +19,26 @@ import RSocketTestUtilities
 @testable import RSocketCore
 
 extension RandomAccessCollection {
-    public subscript(safe index: Index) -> Element? {
+    fileprivate subscript(safe index: Index) -> Element? {
         guard self.indices.contains(index) else { return nil }
         return self[index]
     }
 }
 
 extension FragmentedFrameAssembler {
-    mutating func process(frame: Frame?) -> FragmentationResult? {
+    fileprivate mutating func process(frame: Frame?) -> FragmentationResult? {
         frame.map({ process(frame: $0) })
     }
 }
 
 extension FragmentationResult {
-    var isError: Bool {
+    fileprivate var isError: Bool {
         guard case .error = self else { return false }
         return true
     }
 }
 
-func XCTAssertTrue(
+fileprivate func XCTAssertTrue(
     _ expression: @autoclosure () throws -> Bool?,
     _ message: @autoclosure () -> String,
     file: StaticString = #file,
@@ -46,7 +46,7 @@ func XCTAssertTrue(
 ) {
     XCTAssertEqual(try expression(), true, message(), file: file, line: line)
 }
-func XCTAssertTrue(
+fileprivate func XCTAssertTrue(
     _ expression: @autoclosure () throws -> Bool?,
     file: StaticString = #file,
     line: UInt = #line

--- a/Tests/RSocketCoreTests/PayloadFragmentationTests.swift
+++ b/Tests/RSocketCoreTests/PayloadFragmentationTests.swift
@@ -31,13 +31,6 @@ extension FragmentedFrameAssembler {
     }
 }
 
-fileprivate extension Payload {
-    init(metadata: String? = nil, data: String) {
-        self.init(metadata: metadata.map{ Data($0.utf8) }, data: Data(data.utf8))
-    }
-    var size: Int32 { Int32((metadata?.count ?? 0) + data.count) }
-}
-
 extension FragmentationResult {
     var isError: Bool {
         guard case .error = self else { return false }

--- a/Tests/RSocketCoreTests/PayloadFragmentationTests.swift
+++ b/Tests/RSocketCoreTests/PayloadFragmentationTests.swift
@@ -284,4 +284,20 @@ class PayloadFragmentationTests: XCTestCase {
         XCTAssertEqual(assembler.process(frame: fragments[safe: 0]), .incomplete)
         XCTAssertTrue(assembler.process(frame: fragments[safe: 0])?.isError)
     }
+    func testReceiveSomeMiddleFragmentBeforeReceivingInitalFragmentShouldResultInAnError() {
+        let payload = Payload(
+            metadata: "Some Metadata",
+            data: "Payload with metadata which is too large to fit into a single frame!" +
+                repeatElement(".", count: Int(initialFragmentBodyHeaderSizeWithMetadata))
+        )
+        
+        let frame = makeFrame(payload: payload)
+        let fragments = frame.splitIntoFragmentsIfNeeded(
+            maximumFrameSize: 40 + frameHeaderSizeWithMetadata
+        )
+        XCTAssertEqual(fragments.count, 3)
+
+        var assembler = FragmentedFrameAssembler()
+        XCTAssertTrue(assembler.process(frame: fragments[safe: 1])?.isError)
+    }
 }

--- a/Tests/RSocketCoreTests/PayloadFragmentationTests.swift
+++ b/Tests/RSocketCoreTests/PayloadFragmentationTests.swift
@@ -250,6 +250,9 @@ class PayloadFragmentationTests: XCTestCase {
     
     // - Incomplete Fragmentation
     
+    /// We actually need to support receiving cancelation frames while fragment assembly of a previous frame is till in progress.
+    /// If this will be implemented in `FragmentedFrameAssembler` or somewhere else is not yet decided.
+    /// If it will be implemented inside `FragmentedFrameAssembler` this test should be removed or changed accordingly.
     func testReceiveCancelBeforeReceivingAllFragmentsShouldResultInAnError() {
         let payload = Payload(
             metadata: "Some Metadata",


### PR DESCRIPTION
Test frame fragmentation and assembly. 

### Motivation:

Improve test coverage

### Modifications:
- make it convenient to initialise payload from a string for testing purposes
- write a bunch of test cases

### Result:
Frame fragmentation and assembly is now tested.
Note: An End-to-End test which does fragmentation is still missing because this would result in merge conflicts with #31.
