### PR TITLE
Frame debug description - part 2

### DIFF
--- a/Sources/RSocketCore/Frames/FrameBody/FrameBody.swift
+++ b/Sources/RSocketCore/Frames/FrameBody/FrameBody.swift
@@ -152,8 +152,12 @@ fileprivate func normalizeFrameBodyTypeName<T>(_ type: T.Type) -> String {
 fileprivate func descriptionsOfProperties<T>(_ body: T) -> String {
     Mirror(reflecting: body).children.compactMap({
         guard let label = $0.label else { return nil }
-        return "\(label): \($0.value)"
+        return "\(label): \(debugDescription(of: $0.value))"
     }).joined(separator: ", ")
+}
+
+fileprivate func debugDescription(of value: Any) -> String {
+    (value as? CustomDebugStringConvertible)?.debugDescription ?? String(describing: value)
 }
 
 extension FrameBody: CustomDebugStringConvertible {

--- a/Sources/RSocketCore/Frames/FrameBody/FrameBody.swift
+++ b/Sources/RSocketCore/Frames/FrameBody/FrameBody.swift
@@ -130,3 +130,50 @@ extension FrameBody {
         }
     }
 }
+
+/// creates a description of `body` which looks like the description of an enum where each property of the body is an associated value.
+/// It also removes the redundant `FrameBody` suffix from each type name.
+/// - `PayloadFrameBody(isComplete: true, isNext: false)` will be transformed into `".payload(isComplete: true, isNext: false)"`
+fileprivate func descriptionOfBody<T>(_ body: T) -> String {
+    let typeName = normalizeFrameBodyTypeName(T.self)
+    return ".\(typeName)(\(descriptionsOfProperties(body)))"
+}
+
+/// lowercases the first char of the type name of `T` and removes the `FrameBody` suffix.
+/// - e.g. `RequestResponseFrameBody` becomes `"requestResponse"`
+fileprivate func normalizeFrameBodyTypeName<T>(_ type: T.Type) -> String {
+    let name = String(describing: T.self)
+    guard let firstChar = name.first else { return name }
+    return String(firstChar.lowercased() + name.dropFirst().replacingOccurrences(of: "FrameBody", with: ""))
+}
+
+/// creates a description of all stored properties in the usual format. Property name and value are delimited by `: ` and are then joined by `, `.
+/// - e.g. PayloadFrameBody(isComplete: true, isNext: false) becomes `"isComplete: true, isNext: false"`
+fileprivate func descriptionsOfProperties<T>(_ body: T) -> String {
+    Mirror(reflecting: body).children.compactMap({
+        guard let label = $0.label else { return nil }
+        return "\(label): \($0.value)"
+    }).joined(separator: ", ")
+}
+
+extension FrameBody: CustomDebugStringConvertible {
+    var debugDescription: String {
+        switch self {
+        case let .setup(body): return descriptionOfBody(body)
+        case let .lease(body): return descriptionOfBody(body)
+        case let .keepalive(body): return descriptionOfBody(body)
+        case let .requestResponse(body): return descriptionOfBody(body)
+        case let .requestFnf(body): return descriptionOfBody(body)
+        case let .requestStream(body): return descriptionOfBody(body)
+        case let .requestChannel(body): return descriptionOfBody(body)
+        case let .requestN(body): return descriptionOfBody(body)
+        case let .cancel(body): return descriptionOfBody(body)
+        case let .payload(body): return descriptionOfBody(body)
+        case let .error(body): return descriptionOfBody(body)
+        case let .metadataPush(body): return descriptionOfBody(body)
+        case let .resume(body): return descriptionOfBody(body)
+        case let .resumeOk(body): return descriptionOfBody(body)
+        case let .ext(body): return descriptionOfBody(body)
+        }
+    }
+}

--- a/Sources/RSocketCore/Payload/Payload.swift
+++ b/Sources/RSocketCore/Payload/Payload.swift
@@ -36,3 +36,12 @@ public struct Payload: Hashable {
         self.data = data
     }
 }
+
+extension Payload: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        if metadata == nil && data.isEmpty {
+            return ".empty"
+        }
+        return "Payload(metadata: \(metadata?.debugDescription ?? "nil"), data: \(data))"
+    }
+}

--- a/Sources/RSocketCore/Payload/Payload.swift
+++ b/Sources/RSocketCore/Payload/Payload.swift
@@ -42,6 +42,6 @@ extension Payload: CustomDebugStringConvertible {
         if metadata == nil && data.isEmpty {
             return ".empty"
         }
-        return "Payload(metadata: \(metadata?.debugDescription ?? "nil"), data: \(data))"
+        return "Payload(metadata: \(metadata?.debugDescription ?? "nil"), data: \(data.debugDescription))"
     }
 }


### PR DESCRIPTION
FrameBody `debugDescription` is much shorter

### Motivation:
Debug description of Frames and related types is very verbose and contain redundant information:
```
Frame(streamId: 1, body: RSocketCore.FrameBody.requestStream(RSocketCore.RequestStreamFrameBody(fragmentFollows: false, initialRequestN: 10, payload: RSocketCore.Payload(metadata: nil, data: 0 bytes))))
Frame(streamId: 2, body: RSocketCore.FrameBody.ext(RSocketCore.ExtensionFrameBody(canBeIgnored: false, extendedType: 5, payload: RSocketCore.Payload(metadata: nil, data: 0 bytes))))
Frame(streamId: 3, body: RSocketCore.FrameBody.keepalive(RSocketCore.KeepAliveFrameBody(respondWithKeepalive: true, lastReceivedPosition: 0, data: 0 bytes)))
Frame(streamId: 4, body: RSocketCore.FrameBody.requestResponse(RSocketCore.RequestResponseFrameBody(fragmentFollows: false, payload: RSocketCore.Payload(metadata: Optional(4 bytes), data: 11 bytes))))
Frame(streamId: 5, body: RSocketCore.FrameBody.payload(RSocketCore.PayloadFrameBody(fragmentFollows: false, isCompletion: false, isNext: true, payload: RSocketCore.Payload(metadata: Optional(4 bytes), data: 11 bytes))))
Frame(streamId: .connection, body: RSocketCore.FrameBody.cancel(RSocketCore.CancelFrameBody()))
Frame(streamId: .connection, body: RSocketCore.FrameBody.setup(RSocketCore.SetupFrameBody(honorsLease: false, version: 1.0, timeBetweenKeepaliveFrames: 30000, maxLifetime: 60000, resumeIdentificationToken: nil, metadataEncodingMimeType: "application/json", dataEncodingMimeType: "application/json", payload: RSocketCore.Payload(metadata: nil, data: 0 bytes))))
Frame(streamId: .connection, body: RSocketCore.FrameBody.lease(RSocketCore.LeaseFrameBody(timeToLive: 1000, numberOfRequests: 50, metadata: nil)))
Frame(streamId: .connection, body: RSocketCore.FrameBody.error(RSocketCore.ErrorFrameBody(error: RSocketCore.Error.applicationError(message: "something went wrong"))))
```
The module name is not very helpful and the type of the body is printed twice.

### Modifications:
- module name and redundant type annotations is no longer included in the debug description
- if payload is empty (i.e. metadata == nil and data is empty) `.empty` is printed

### Result:

```
Frame(streamId: 1, body: .requestStream(fragmentFollows: false, initialRequestN: 10, payload: .empty))
Frame(streamId: 2, body: .extension(canBeIgnored: false, extendedType: 5, payload: .empty))
Frame(streamId: 3, body: .keepAlive(respondWithKeepalive: true, lastReceivedPosition: 0, data: 0 bytes))
Frame(streamId: 4, body: .requestResponse(fragmentFollows: false, payload: Payload(metadata: 4 bytes, data: 11 bytes)))
Frame(streamId: 5, body: .payload(fragmentFollows: false, isCompletion: false, isNext: true, payload: Payload(metadata: 4 bytes, data: 11 bytes)))
Frame(streamId: .connection, body: .cancel())
Frame(streamId: .connection, body: .setup(honorsLease: false, version: 1.0, timeBetweenKeepaliveFrames: 30000, maxLifetime: 60000, resumeIdentificationToken: nil, metadataEncodingMimeType: "application/json", dataEncodingMimeType: "application/json", payload: .empty))
Frame(streamId: .connection, body: .lease(timeToLive: 1000, numberOfRequests: 50, metadata: nil))
Frame(streamId: .connection, body: .error(error: applicationError(message: "something went wrong")))
```

We may want to add an easy way to print the contents of a `Payload` but I think this should not be the default.