### PR TITLE
makes Error extensible

### DIFF
--- a/Sources/RSocketCore/Frames/Frame+Validate.swift
+++ b/Sources/RSocketCore/Frames/Frame+Validate.swift
@@ -22,7 +22,7 @@ extension Frame {
         switch body {
         case let .error(body):
             if header.streamId == .connection {
-                switch body.error {
+                switch body.error.code {
                 case .invalidSetup, .unsupportedSetup, .rejectedSetup, .connectionError, .connectionClose:
                     break
 
@@ -30,11 +30,11 @@ extension Frame {
                     throw Error.connectionError(message: "The given error code is not valid for this streamId")
                 }
             } else {
-                switch body.error {
+                switch body.error.code {
                 case .applicationError, .rejected, .canceled, .invalid:
                     break
 
-                case .other where body.error.isApplicationLayerError:
+                case _ where body.error.code.isApplicationLayerError:
                     break
 
                 default:

--- a/Sources/RSocketCore/Frames/FrameBody/Error/ErrorFrameBodyDecoder.swift
+++ b/Sources/RSocketCore/Frames/FrameBody/Error/ErrorFrameBodyDecoder.swift
@@ -30,7 +30,7 @@ internal struct ErrorFrameBodyDecoder: FrameBodyDecoding {
         } else {
             message = ""
         }
-        let error = Error(code: code, message: message)
+        let error = Error(code: .init(rawValue: code), message: message)
         return ErrorFrameBody(error: error)
     }
 }

--- a/Sources/RSocketCore/Frames/FrameBody/Error/ErrorFrameBodyEncoder.swift
+++ b/Sources/RSocketCore/Frames/FrameBody/Error/ErrorFrameBodyEncoder.swift
@@ -18,7 +18,7 @@ import NIO
 
 internal struct ErrorFrameBodyEncoder: FrameBodyEncoding {
     internal func encode(frame: ErrorFrameBody, into buffer: inout ByteBuffer) throws {
-        buffer.writeInteger(frame.error.code)
+        buffer.writeInteger(frame.error.code.rawValue)
         if !frame.error.message.isEmpty {
             let bytesWritten = buffer.writeString(frame.error.message)
             guard bytesWritten > 0 else {

--- a/Tests/RSocketCoreTests/KeepaliveHandlerTests.swift
+++ b/Tests/RSocketCoreTests/KeepaliveHandlerTests.swift
@@ -90,7 +90,7 @@ final class KeepaliveHandlerTests: XCTestCase {
         let frame = try XCTUnwrap(try channel.readOutbound(as: Frame.self))
         switch frame.body {
         case let .error(body):
-            XCTAssertEqual(body.error.kind, .connectionClose)
+            XCTAssertEqual(body.error.code, .connectionClose)
         default:
             XCTFail("connection should be closed but \(frame) was send")
         }

--- a/Tests/RSocketCoreTests/SetupValidationTests.swift
+++ b/Tests/RSocketCoreTests/SetupValidationTests.swift
@@ -52,14 +52,14 @@ final class SetupValidationTests: XCTestCase {
         XCTAssertThrowsError(try validator.validate(frame: goodSetup.modify({
             $0.version = Version(major: 1, minor: 1)
         }).asFrame())){ error in
-            XCTAssertEqual((error as? RSocketCore.Error)?.kind, .unsupportedSetup)
+            XCTAssertEqual((error as? RSocketCore.Error)?.code, .unsupportedSetup)
         }
     }
     func testLeaseIsNotSupported() {
         XCTAssertThrowsError(try validator.validate(frame: goodSetup.modify({
             $0.honorsLease = true
         }).asFrame())){ error in
-            XCTAssertEqual((error as? RSocketCore.Error)?.kind, .unsupportedSetup)
+            XCTAssertEqual((error as? RSocketCore.Error)?.code, .unsupportedSetup)
         }
     }
     func testResumeIsRejected() {
@@ -69,7 +69,7 @@ final class SetupValidationTests: XCTestCase {
             lastReceivedServerPosition: 5,
             firstAvailableClientPosition: 6
         ).asFrame())) { error in
-            XCTAssertEqual((error as? RSocketCore.Error)?.kind, .rejectedResume)
+            XCTAssertEqual((error as? RSocketCore.Error)?.code, .rejectedResume)
         }
     }
 }


### PR DESCRIPTION
Allows user code to add custom error codes 

### Motivation:
A user should be able to easily define and use custom application errors

### Modifications:
- `Error` is now a struct instead of an enum with two stored properties `code` and `message`
- `Error.Code` is a new struct which is a thin wrapper around a UInt32 which allows to add custom error codes through extensions

### Result:
A user can now define custom errors by writing two extensions:
```
extension Error.Code {
    static let myCustomError = Self(rawValue: 0x00000301)
}
extension Error {
    static func myCustomError(message: String) -> Self { .init(code: .myCustomError, message: message ) }
}
```
Custom Errors can be used in the same places as predefined errors and behave the same too.