### PR TITLE
adds NIOWebSocketFrameAggregator to buffer fragmented WS frames

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {
           "branch": null,
-          "revision": "3be4e0980075de10a4bc8dee07491d49175cfd7a",
-          "version": "2.27.0"
+          "revision": "6befe13e234e7fa4be6e0e9d8f9d06ee18bb589c",
+          "version": null
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {
           "branch": null,
-          "revision": "6befe13e234e7fa4be6e0e9d8f9d06ee18bb589c",
-          "version": null
+          "revision": "d161bf658780b209c185994528e7e24376cf7283",
+          "version": "2.29.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.6.0"),
-        .package(url: "https://github.com/apple/swift-nio", from: "2.26.0"),
+        // TODO: WebSocketFrameAggregator is not yet release in an official version. Change to "from: ..." when swift-nio release a new version
+        .package(url: "https://github.com/apple/swift-nio", .revision("6befe13e234e7fa4be6e0e9d8f9d06ee18bb589c")),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.8.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services", from: "1.9.2"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.10.4"),

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.6.0"),
-        // TODO: WebSocketFrameAggregator is not yet release in an official version. Change to "from: ..." when swift-nio release a new version
-        .package(url: "https://github.com/apple/swift-nio", .revision("6befe13e234e7fa4be6e0e9d8f9d06ee18bb589c")),
+        .package(url: "https://github.com/apple/swift-nio", from: "2.29.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.8.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services", from: "1.9.2"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.10.4"),

--- a/Sources/RSocketWSTransport/WSTransport.swift
+++ b/Sources/RSocketWSTransport/WSTransport.swift
@@ -43,7 +43,22 @@ public struct WSTransport {
             self.additionalHTTPHeader = additionalHTTPHeader
         }
     }
-    public init() {}
+
+    private let minNonFinalFragmentSize: Int
+    private let maxAccumulatedFrameCount: Int
+
+    /// WebSocket Transport for RSocket
+    /// - Parameters:
+    ///   - minNonFinalFragmentSize: Minimum size in bytes of a fragment which is not the last fragment of a complete frame. Used to defend agains many really small payloads. Default is `0`.
+    ///   - maxAccumulatedFrameCount: Maximum number of fragments which are allowed to result in a complete frame. Defaults to `Int.max`
+    ///   - Note: Maximum accumulated size in bytes of buffered fragments is configured through `ClientConfiguration.Fragmentation`
+    public init(
+        minNonFinalFragmentSize: Int = 0,
+        maxAccumulatedFrameCount: Int = Int.max
+    ) {
+        self.minNonFinalFragmentSize = minNonFinalFragmentSize
+        self.maxAccumulatedFrameCount = maxAccumulatedFrameCount
+    }
 }
 
 extension WSTransport.Endpoint: Endpoint {
@@ -88,6 +103,11 @@ extension WSTransport: TransportChannelHandler {
             maxFrameSize: maximumIncomingFragmentSize,
             upgradePipelineHandler: { channel, _ in
                 channel.pipeline.addHandlers([
+                    NIOWebSocketFrameAggregator(
+                        minNonFinalFragmentSize: minNonFinalFragmentSize,
+                        maxAccumulatedFrameCount: maxAccumulatedFrameCount,
+                        maxAccumulatedFrameSize: maximumIncomingFragmentSize
+                    ),
                     WebSocketFrameToByteBuffer(),
                     WebSocketFrameFromByteBuffer(),
                 ])

--- a/Sources/RSocketWSTransport/WebSocketFrameToByteBuffer.swift
+++ b/Sources/RSocketWSTransport/WebSocketFrameToByteBuffer.swift
@@ -25,7 +25,7 @@ final class WebSocketFrameToByteBuffer: ChannelInboundHandler {
         let frame = unwrapInboundIn(data)
         switch frame.opcode {
         case .continuation:
-            /// we currently do not support WebSocket fragmentation
+            assertionFailure("NIOWebSocketFrameAggregator should not let any `.continuation` frames through")
             break
         case .connectionClose:
             /// TODO: We probably want to handle it the same as if an RSocket close frame and close the connection gracefully


### PR DESCRIPTION
### Motivation:

We want support frame fragmentation at the WebSocket level

### Modifications:

add NIOWebSocketFrameAggregator to channel pipeline in front of our own channel handlers

### Result:

Fragmented WebSocket Frames are now supported.

### Discussion

What are good default values for `minNonFinalFragmentSize` and `maxAccumulatedFrameCount` for WebSocket?
The equivalent of `minNonFinalFragmentSize` in RSocket would be 64 bytes but I don't know if this is appropriate for WebSocket as well.
I have set `minNonFinalFragmentSize` by default to `0` and `maxAccumulatedFrameCount` to `Int.max` for now.

`minNonFinalFragmentSize` and `maxAccumulatedFrameCount` are part of `WSTransport` and not `ClientConfiguration` because they are specific to WebSocket. I kind of want them to be part of `ClientConfiguration`. I initially thought that we could just add these properties to `ClientConfiguration.Fragmentation` and even use the same values for WebSocket fragmentation and RSocket fragmentation. But that would mean one can not configure fragmentation separately for WebSocket and for RSocket... Maybe that's good thing, less configuration one has to worry about is in general a good thing. However, I can't say for sure that RSocket fragmentation and WebSocket fragmentation should always have the same buffer limits. 