### PR TITLE
use SwiftNIO version of random masking and request key

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {
-          "branch": "main",
-          "revision": "465f87dd7cbc93f6ce6e49f668955a42ac99c641",
-          "version": null
+          "branch": null,
+          "revision": "d79e33308b0ac83326b0ead0ea6446e604b8162d",
+          "version": "2.30.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,9 +23,9 @@
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {
-          "branch": null,
-          "revision": "3be4e0980075de10a4bc8dee07491d49175cfd7a",
-          "version": "2.27.0"
+          "branch": "main",
+          "revision": "465f87dd7cbc93f6ce6e49f668955a42ac99c641",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.6.0"),
-        .package(url: "https://github.com/apple/swift-nio", from: "2.26.0"),
+        /// TODO: use `from: "2.30.0"` after swift-nio releases a new minior version
+        .package(url: "https://github.com/apple/swift-nio", .branch("main")),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.8.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services", from: "1.9.2"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.10.4"),

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.6.0"),
-        /// TODO: use `from: "2.30.0"` after swift-nio releases a new minior version
-        .package(url: "https://github.com/apple/swift-nio", .branch("main")),
+        .package(url: "https://github.com/apple/swift-nio", from: "2.30.0"),
         .package(url: "https://github.com/apple/swift-nio-extras", from: "1.8.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services", from: "1.9.2"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.10.4"),

--- a/Sources/RSocketWSTransport/WSTransport.swift
+++ b/Sources/RSocketWSTransport/WSTransport.swift
@@ -20,20 +20,6 @@ import NIOHTTP1
 import NIOWebSocket
 import RSocketCore
 
-/// generates 16 bytes randomly and encodes them as a base64 string as defined in RFC6455 https://tools.ietf.org/html/rfc6455#section-4.1
-/// - Returns: base64 encoded string
-fileprivate func randomRequestKey() -> String {
-    /// we may want to use `randomBytes(count:)` once the proposal is accepted: https://forums.swift.org/t/pitch-requesting-larger-amounts-of-randomness-from-systemrandomnumbergenerator/27226
-    let lower = UInt64.random(in: UInt64.min...UInt64.max)
-    let upper = UInt64.random(in: UInt64.min...UInt64.max)
-    let data = withUnsafeBytes(of: lower) { lowerBytes in
-        withUnsafeBytes(of: upper) { upperBytes in
-            Data(lowerBytes) + Data(upperBytes)
-        }
-    }
-    return data.base64EncodedString()
-}
-
 public struct WSTransport {
     public struct Endpoint {
         public var url: URL
@@ -84,7 +70,6 @@ extension WSTransport: TransportChannelHandler {
             additionalHTTPHeader: endpoint.additionalHTTPHeader
         )
         let websocketUpgrader = NIOWebSocketClientUpgrader(
-            requestKey: randomRequestKey(),
             maxFrameSize: maximumIncomingFragmentSize,
             upgradePipelineHandler: { channel, _ in
                 channel.pipeline.addHandlers([

--- a/Sources/RSocketWSTransport/WebSocketFrameFromByteBuffer.swift
+++ b/Sources/RSocketWSTransport/WebSocketFrameFromByteBuffer.swift
@@ -17,18 +17,12 @@
 import NIO
 import NIOWebSocket
 
-fileprivate func randomMaskingKey() -> WebSocketMaskingKey {
-    let mask = UInt32.random(in: UInt32.min...UInt32.max)
-    return withUnsafeBytes(of: mask) { WebSocketMaskingKey($0)! }
-}
-
 final class WebSocketFrameFromByteBuffer: ChannelOutboundHandler {
     typealias OutboundIn = ByteBuffer
     typealias OutboundOut = WebSocketFrame
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let buffer = unwrapOutboundIn(data)
-        let maskKey = randomMaskingKey()
-        let frame = WebSocketFrame(fin: true, opcode: .binary, maskKey: maskKey, data: buffer)
+        let frame = WebSocketFrame(fin: true, opcode: .binary, maskKey: .random(), data: buffer)
         context.write(wrapOutboundOut(frame), promise: promise)
     }
 }


### PR DESCRIPTION
### Motivation:
I have moved the implementation of the random masking key and request key to swift-nio:
https://github.com/apple/swift-nio/pull/1824
https://github.com/apple/swift-nio/pull/1855

### Modifications:

delete our implementation and use the implementation provided by swift-nio

### Result:

less code we have to maintain
