### PR TITLE
fix custom debugDescription/description overload in RSocketTestUtilities

### DIFF
--- a/Sources/RSocketCore/Payload/Payload.swift
+++ b/Sources/RSocketCore/Payload/Payload.swift
@@ -37,8 +37,9 @@ public struct Payload: Hashable {
     }
 }
 
-extension Payload: CustomDebugStringConvertible {
-    public var debugDescription: String {
+// Payload implements `CustomStringConvertible` instead of `CustomDebugStringConvertible` to allow `RSocketTestUtilities` to customize the debug output.
+extension Payload: CustomStringConvertible {
+    public var description: String {
         if metadata == nil && data.isEmpty {
             return ".empty"
         }


### PR DESCRIPTION
### Motivation:
The Swift Compiler warns us that Payload conforms to `CustomDebugStringConvertible` twice, which is not supported by Swift.

### Modifications:
Conform `Payload` to `CustomStringConvertible` in `RSocketCore` and only to `CustomDebugStringConvertible` in `RSocketTestUtilities`. 

### Result:
Payload tries to read it's metadata and data as a UTF-8 string when `RSocketTestUtilities` is imported.
Otherwise it just prints the size of metadata/data in bytes.
