### PR TITLE
adds support for Composite Metadata

### DIFF
--- a/Sources/RSocketCore/Extensions/CompositeMetadata.swift
+++ b/Sources/RSocketCore/Extensions/CompositeMetadata.swift
@@ -17,7 +17,7 @@
 import Foundation
 import NIO
 
-public struct CompositeMetadata {
+public struct CompositeMetadata: Equatable {
     public var mimeType: MIMEType
     public var data: Data
     public init(mimeType: MIMEType, data: Data) {

--- a/Sources/RSocketCore/Extensions/RootCompositeMetadataDecoder.swift
+++ b/Sources/RSocketCore/Extensions/RootCompositeMetadataDecoder.swift
@@ -36,6 +36,7 @@ public struct RootCompositeMetadataDecoder: MetadataDecoder {
         while buffer.readableBytes != 0 {
             result.append(try decodeSingleCompositeMetadata(from: &buffer))
         }
+        return result
     }
     
     @inlinable
@@ -58,7 +59,7 @@ public extension MetadataDecoder where Self == RootCompositeMetadataDecoder {
 
 extension Sequence where Element == CompositeMetadata {
     @inlinable
-    func decodeFirstIfPresent<Decoder>(
+    internal func decodeFirstIfPresent<Decoder>(
         using decoder: Decoder
     ) throws -> Decoder.Metadata? where Decoder: MetadataDecoder {
         guard let data = first(where: { $0.mimeType == decoder.mimeType })?.data else {
@@ -67,7 +68,7 @@ extension Sequence where Element == CompositeMetadata {
         return try decoder.decode(from: data)
     }
     @inlinable
-    func decodeFirst<Decoder>(
+    internal func decodeFirst<Decoder>(
         using decoder: Decoder
     ) throws -> Decoder.Metadata where Decoder: MetadataDecoder {
         guard let metadata = try decodeFirstIfPresent(using: decoder) else {

--- a/Sources/RSocketCore/Extensions/RootCompositeMetadataEncoder.swift
+++ b/Sources/RSocketCore/Extensions/RootCompositeMetadataEncoder.swift
@@ -32,7 +32,19 @@ public struct RootCompositeMetadataEncoder: MetadataEncoder {
     
     @inlinable
     public func encode(_ metadata: Metadata, into buffer: inout ByteBuffer) throws {
-        fatalError("not implemented")
+        for compositeMetadata in metadata {
+            try encodeSingleCompositeMetadata(compositeMetadata, into: &buffer)
+        }
+    }
+    
+    @inlinable
+    public func encodeSingleCompositeMetadata(
+        _ metadata: CompositeMetadata, 
+        into buffer: inout ByteBuffer
+    ) throws {
+        try mimeTypeEncoder.encode(metadata.mimeType, into: &buffer)
+        try buffer.writeUInt24WithBoundsCheck(metadata.data.count)
+        buffer.writeData(metadata.data)
     }
 }
 

--- a/Sources/RSocketCore/Extensions/RootCompositeMetadataEncoder.swift
+++ b/Sources/RSocketCore/Extensions/RootCompositeMetadataEncoder.swift
@@ -38,7 +38,7 @@ public struct RootCompositeMetadataEncoder: MetadataEncoder {
     }
     
     @inlinable
-    public func encodeSingleCompositeMetadata(
+    internal func encodeSingleCompositeMetadata(
         _ metadata: CompositeMetadata, 
         into buffer: inout ByteBuffer
     ) throws {

--- a/Sources/RSocketCore/Utility/ByteBuffer+UInt24.swift
+++ b/Sources/RSocketCore/Utility/ByteBuffer+UInt24.swift
@@ -17,6 +17,12 @@
 import NIO
 
 extension ByteBuffer {
+    enum UInt24Error: Swift.Error {
+        case doesNotFitExactlyIntoUInt24
+    }
+}
+
+extension ByteBuffer {
     @discardableResult
     @inlinable
     internal mutating func setUInt24<T: FixedWidthInteger & UnsignedInteger>(
@@ -56,6 +62,21 @@ extension ByteBuffer {
         let bytesWritten = setUInt24(integer, at: writerIndex, endianness: endianness)
         moveWriterIndex(forwardBy: bytesWritten)
         return bytesWritten
+    }
+    
+    @discardableResult
+    @inlinable
+    internal mutating func writeUInt24WithBoundsCheck<T: FixedWidthInteger>(
+        _ integer: T,
+        endianness: Endianness = .big,
+        as: T.Type = T.self
+    ) throws -> Int {
+        guard let integer = UInt32(exactly: integer),
+              integer < (1 << 24 - 1)
+        else {
+            throw UInt24Error.doesNotFitExactlyIntoUInt24
+        }
+        return writeUInt24(integer, endianness: endianness)
     }
 
     @inlinable

--- a/Sources/RSocketCore/Utility/ByteBuffer+UInt24.swift
+++ b/Sources/RSocketCore/Utility/ByteBuffer+UInt24.swift
@@ -16,10 +16,10 @@
 
 import NIO
 
-extension ByteBuffer {
-    enum UInt24Error: Swift.Error {
-        case doesNotFitExactlyIntoUInt24
-    }
+
+@usableFromInline
+enum UInt24Error: Swift.Error {
+    case doesNotFitExactlyIntoUInt24
 }
 
 extension ByteBuffer {
@@ -72,7 +72,7 @@ extension ByteBuffer {
         as: T.Type = T.self
     ) throws -> Int {
         guard let integer = UInt32(exactly: integer),
-              integer < (1 << 24 - 1)
+              integer <= (1 << 24 - 1)
         else {
             throw UInt24Error.doesNotFitExactlyIntoUInt24
         }

--- a/Tests/RSocketCoreTests/Extensions/RootCompositeMetadataCoderTests.swift
+++ b/Tests/RSocketCoreTests/Extensions/RootCompositeMetadataCoderTests.swift
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import NIO
+@testable import RSocketCore
+
+fileprivate let UInt24Max = 1 << 24 - 1
+
+final class RootCompositeMetadataCoderTests: XCTestCase {
+    func testValid() throws {
+        let validCompositeMetadataList: [[CompositeMetadata]] = [
+            [
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data()),
+            ],
+            [
+                CompositeMetadata(mimeType: .applicationJson, data: Data("{}".utf8)),
+            ],
+            [
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data([0])),
+            ],
+            [
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data([0, 1])),
+            ],
+
+            [
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data([])),
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data([0])),
+            ],
+            [
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data([])),
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data([0])),
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data([1, 2])),
+            ],
+
+            [
+                CompositeMetadata(mimeType: .messageXRSocketRoutingV0, data: Data([6] + "stocks".utf8)),
+                CompositeMetadata(mimeType: .applicationJson, data: Data(#"{"isin":"US0378331005"}"#.utf8)),
+            ],
+            [
+                CompositeMetadata(mimeType: .init(rawValue: "my-custom/mimetype"), data: Data([0])),
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data([1])),
+            ],
+
+            [
+                CompositeMetadata(mimeType: .applicationOctetStream, data: Data(repeating: 0, count: UInt24Max)),
+            ],
+        ]
+
+        for validCompositeMetadata in validCompositeMetadataList {
+            let encoder = RootCompositeMetadataEncoder()
+            let encodedData = try encoder.encode(validCompositeMetadata)
+
+            let decoder = RootCompositeMetadataDecoder()
+            let decodedCompositeMetadata = try decoder.decode(from: encodedData)
+            XCTAssertEqual(decodedCompositeMetadata, validCompositeMetadata)
+        }
+    }
+
+    func testTooBigMetadata() {
+        XCTAssertThrowsError(
+            try RootCompositeMetadataEncoder()
+                .encode([
+                    CompositeMetadata(mimeType: .applicationOctetStream, data: Data(repeating: 0, count: UInt24Max + 1))
+                ])
+        )
+    }
+
+    func testMessageToShort() throws {
+        var compositeMetadata = ByteBuffer()
+        try MIMETypeEncoder().encode(.applicationJson, into: &compositeMetadata)
+        compositeMetadata.writeUInt24(UInt32(1))
+
+        XCTAssertThrowsError(
+            try RootCompositeMetadataDecoder()
+                .decode(from: &compositeMetadata)
+        )
+    }
+}


### PR DESCRIPTION
### Motivation:

We want to support the [Composite Metadata Extension](https://github.com/rsocket/rsocket/blob/master/Extensions/CompositeMetadata.md)

### Modifications:

- implements `RootCompositeMetadataDecoder` and `RootCompositeMetadataEncoder`
- make `CompositeMetadata` conform to `Equatable` for easier testing 
- adds tests 

### Result:

we now support the Composite Metadata Extension
