### PR TITLE
new Promise protocol to better model `REQUEST_RESPONSE` streams

### DIFF
--- a/Sources/RSocketCore/DefaultRSocket.swift
+++ b/Sources/RSocketCore/DefaultRSocket.swift
@@ -18,9 +18,10 @@ import Foundation
 
 /// A stream which does not do anything.
 fileprivate final class NoOpStream: UnidirectionalStream {
-    func onNext(_ payload: Payload, isCompletion: Bool) {}
+    func onNext(_ payload: Payload) {}
     func onError(_ error: Error) {}
     func onComplete() {}
+    func onComplete(_ payload: Payload) {}
     func onExtension(extendedType: Int32, payload: Payload, canBeIgnored: Bool) {}
     func onRequestN(_ requestN: Int32) {}
     func onCancel() {}
@@ -31,7 +32,7 @@ fileprivate final class NoOpStream: UnidirectionalStream {
 internal struct DefaultRSocket: RSocket {
     func metadataPush(metadata: Data) {}
     func fireAndForget(payload: Payload) {}
-    func requestResponse(payload: Payload, responderStream: UnidirectionalStream) -> Cancellable {
+    func requestResponse(payload: Payload, responderStream: Promise) -> Cancellable {
         responderStream.onError(.rejected(message: "not implemented"))
         return NoOpStream()
     }

--- a/Sources/RSocketCore/DefaultRSocket.swift
+++ b/Sources/RSocketCore/DefaultRSocket.swift
@@ -32,8 +32,8 @@ fileprivate final class NoOpStream: UnidirectionalStream {
 internal struct DefaultRSocket: RSocket {
     func metadataPush(metadata: Data) {}
     func fireAndForget(payload: Payload) {}
-    func requestResponse(payload: Payload, responderStream: Promise) -> Cancellable {
-        responderStream.onError(.rejected(message: "not implemented"))
+    func requestResponse(payload: Payload, responderPromise: Promise) -> Cancellable {
+        responderPromise.onError(.rejected(message: "not implemented"))
         return NoOpStream()
     }
     func stream(payload: Payload, initialRequestN: Int32, responderStream: UnidirectionalStream) -> Subscription {

--- a/Sources/RSocketCore/RSocket.swift
+++ b/Sources/RSocketCore/RSocket.swift
@@ -21,7 +21,7 @@ public protocol RSocket {
     
     func fireAndForget(payload: Payload)
     
-    func requestResponse(payload: Payload, responderStream: Promise) -> Cancellable
+    func requestResponse(payload: Payload, responderPromise: Promise) -> Cancellable
     
     func stream(payload: Payload, initialRequestN: Int32, responderStream: UnidirectionalStream) -> Subscription
     

--- a/Sources/RSocketCore/RSocket.swift
+++ b/Sources/RSocketCore/RSocket.swift
@@ -21,7 +21,7 @@ public protocol RSocket {
     
     func fireAndForget(payload: Payload)
     
-    func requestResponse(payload: Payload, responderStream: UnidirectionalStream) -> Cancellable
+    func requestResponse(payload: Payload, responderStream: Promise) -> Cancellable
     
     func stream(payload: Payload, initialRequestN: Int32, responderStream: UnidirectionalStream) -> Subscription
     

--- a/Sources/RSocketCore/Streams/Requester.swift
+++ b/Sources/RSocketCore/Streams/Requester.swift
@@ -86,7 +86,7 @@ extension Requester: RSocket {
         terminationBehaviour: TerminationBehaviour,
         initialFrame body: Body
     ) -> ThreadSafeStreamAdapter where Body: FrameBodyBoundToStream {
-        let adapter = ThreadSafeStreamAdapter(eventLoop: eventLoop)
+        let adapter = ThreadSafeStreamAdapter(eventLoop: eventLoop, shouldOnNextCompleteStream: false)
         eventLoop.enqueueOrCallImmediatelyIfInEventLoop { [self] in
             let newId = generateNewStreamId()
             let stream = RequesterStream(
@@ -104,9 +104,9 @@ extension Requester: RSocket {
         return adapter
     }
     
-    func requestResponse(payload: Payload, responderStream: Promise) -> Cancellable {
+    func requestResponse(payload: Payload, responderPromise: Promise) -> Cancellable {
         return createAndAddStream(
-            responderStream: .requestResponse(responderStream),
+            responderStream: .requestResponse(responderPromise),
             terminationBehaviour: RequestResponseTerminationBehaviour(),
             initialFrame: RequestResponseFrameBody(payload: payload)
         )

--- a/Sources/RSocketCore/Streams/Requester.swift
+++ b/Sources/RSocketCore/Streams/Requester.swift
@@ -82,7 +82,7 @@ extension Requester: RSocket {
     }
     
     private func createAndAddStream<Body>(
-        responderStream: UnidirectionalStream,
+        responderStream: RequesterStream.StreamKind,
         terminationBehaviour: TerminationBehaviour,
         initialFrame body: Body
     ) -> ThreadSafeStreamAdapter where Body: FrameBodyBoundToStream {
@@ -104,9 +104,9 @@ extension Requester: RSocket {
         return adapter
     }
     
-    func requestResponse(payload: Payload, responderStream: UnidirectionalStream) -> Cancellable {
+    func requestResponse(payload: Payload, responderStream: Promise) -> Cancellable {
         return createAndAddStream(
-            responderStream: responderStream,
+            responderStream: .requestResponse(responderStream),
             terminationBehaviour: RequestResponseTerminationBehaviour(),
             initialFrame: RequestResponseFrameBody(payload: payload)
         )
@@ -114,7 +114,7 @@ extension Requester: RSocket {
     
     func stream(payload: Payload, initialRequestN: Int32, responderStream: UnidirectionalStream) -> Subscription {
         return createAndAddStream(
-            responderStream: responderStream,
+            responderStream: .stream(responderStream),
             terminationBehaviour: StreamTerminationBehaviour(),
             initialFrame: RequestStreamFrameBody(
                 initialRequestN: initialRequestN,
@@ -130,7 +130,7 @@ extension Requester: RSocket {
         responderStream: UnidirectionalStream
     ) -> UnidirectionalStream {
         return createAndAddStream(
-            responderStream: responderStream,
+            responderStream: .channel(responderStream),
             terminationBehaviour: ChannelTerminationBehaviour(),
             initialFrame: RequestChannelFrameBody(
                 isCompleted: isCompleted,

--- a/Sources/RSocketCore/Streams/Stream.swift
+++ b/Sources/RSocketCore/Streams/Stream.swift
@@ -28,6 +28,7 @@ public protocol Subscription: Cancellable {
     func onRequestN(_ requestN: Int32)
 }
 
-public protocol UnidirectionalStream: Promise, Subscription {
+public protocol UnidirectionalStream: Subscription {
+    func onNext(_ payload: Payload)
     func onComplete()
 }

--- a/Sources/RSocketCore/Streams/Stream.swift
+++ b/Sources/RSocketCore/Streams/Stream.swift
@@ -20,11 +20,14 @@ public protocol Cancellable {
     func onExtension(extendedType: Int32, payload: Payload, canBeIgnored: Bool)
 }
 
+public protocol Promise: Cancellable {
+    func onNext(_ payload: Payload)
+}
+
 public protocol Subscription: Cancellable {
     func onRequestN(_ requestN: Int32)
 }
 
-public protocol UnidirectionalStream: Subscription {
-    func onNext(_ payload: Payload, isCompletion: Bool)
+public protocol UnidirectionalStream: Promise, Subscription {
     func onComplete()
 }

--- a/Sources/RSocketCore/Streams/ThreadSafeStreamAdapter.swift
+++ b/Sources/RSocketCore/Streams/ThreadSafeStreamAdapter.swift
@@ -43,8 +43,8 @@ extension ThreadSafeStreamAdapter: UnidirectionalStream {
         }
     }
     
-    internal func onNext(_ payload: Payload, isCompletion: Bool) {
-        send(PayloadFrameBody(isCompletion: isCompletion, isNext: true, payload: payload))
+    internal func onNext(_ payload: Payload) {
+        send(PayloadFrameBody(isCompletion: false, isNext: true, payload: payload))
     }
     internal func onError(_ error: Error) {
         send(ErrorFrameBody(error: error))
@@ -60,5 +60,11 @@ extension ThreadSafeStreamAdapter: UnidirectionalStream {
     }
     internal func onExtension(extendedType: Int32, payload: Payload, canBeIgnored: Bool) {
         send(ExtensionFrameBody(canBeIgnored: canBeIgnored, extendedType: extendedType, payload: payload))
+    }
+}
+
+extension ThreadSafeStreamAdapter: Promise {
+    internal func onComplete(_ payload: Payload) {
+        send(PayloadFrameBody(isCompletion: true, isNext: true, payload: payload))
     }
 }

--- a/Sources/RSocketReactiveSwift/Requester.swift
+++ b/Sources/RSocketReactiveSwift/Requester.swift
@@ -36,7 +36,7 @@ internal struct RequesterAdapter: RSocket {
     internal func requestResponse(payload: Payload) -> SignalProducer<Payload, Swift.Error> {
         SignalProducer { observer, lifetime in
             let stream = RequestResponseOperator(observer: observer)
-            let output = requester.requestResponse(payload: payload, responderStream: stream)
+            let output = requester.requestResponse(payload: payload, responderPromise: stream)
             lifetime.observeEnded {
                 output.onCancel()
             }

--- a/Sources/RSocketReactiveSwift/Requester.swift
+++ b/Sources/RSocketReactiveSwift/Requester.swift
@@ -76,18 +76,14 @@ fileprivate struct RequestResponseOperator {
     }
 }
 
-extension RequestResponseOperator: UnidirectionalStream {
-    func onNext(_ payload: Payload, isCompletion: Bool) {
+extension RequestResponseOperator: Promise {
+    func onNext(_ payload: Payload) {
         observer.send(value: payload)
         observer.sendCompleted()
     }
     
     func onError(_ error: Error) {
         observer.send(error: error)
-    }
-    
-    func onComplete() {
-        observer.sendCompleted()
     }
     
     func onCancel() {
@@ -116,11 +112,8 @@ fileprivate struct RequestStreamOperator {
 }
 
 extension RequestStreamOperator: UnidirectionalStream {
-    func onNext(_ payload: Payload, isCompletion: Bool) {
+    func onNext(_ payload: Payload) {
         observer.send(value: payload)
-        if isCompletion {
-            observer.sendCompleted()
-        }
     }
     
     func onError(_ error: Error) {
@@ -164,7 +157,7 @@ fileprivate final class RequestChannelOperator {
         payloadProducerDisposable = payloadProducer?.start { event in
             switch event {
             case let .value(value):
-                output.onNext(value, isCompletion: false)
+                output.onNext(value)
             case let .failed(error):
                 output.onError(Error.applicationError(message: error.localizedDescription))
             case .completed:
@@ -181,12 +174,8 @@ fileprivate final class RequestChannelOperator {
 }
 
 extension RequestChannelOperator: UnidirectionalStream {
-    func onNext(_ payload: Payload, isCompletion: Bool) {
+    func onNext(_ payload: Payload) {
         observer.send(value: payload)
-        if isCompletion {
-            isTerminated = true
-            observer.sendCompleted()
-        }
     }
     
     func onError(_ error: Error) {

--- a/Sources/RSocketReactiveSwift/Responder.swift
+++ b/Sources/RSocketReactiveSwift/Responder.swift
@@ -33,10 +33,10 @@ internal struct ResponderAdapter: RSocketCore.RSocket {
         responder.fireAndForget(payload: payload)
     }
     
-    func requestResponse(payload: Payload, responderStream: Promise) -> Cancellable {
+    func requestResponse(payload: Payload, responderPromise: Promise) -> Cancellable {
         RequestResponseResponder(
             producer: responder.requestResponse(payload: payload),
-            output: responderStream
+            output: responderPromise
         )
     }
     

--- a/Sources/RSocketTestUtilities/TestRSocket.swift
+++ b/Sources/RSocketTestUtilities/TestRSocket.swift
@@ -21,7 +21,7 @@ import RSocketCore
 public final class TestRSocket: RSocket {
     public var metadataPush: ((Data) -> ())? = nil
     public var fireAndForget: ((_ payload: Payload) -> ())? = nil
-    public var requestResponse: ((_ payload: Payload, _ responderOutput: UnidirectionalStream) -> Cancellable)? = nil
+    public var requestResponse: ((_ payload: Payload, _ responderOutput: Promise) -> Cancellable)? = nil
     public var stream: ((_ payload: Payload, _ initialRequestN: Int32, _ responderOutput: UnidirectionalStream) -> Subscription)? = nil
     public var channel: ((_ payload: Payload, _ initialRequestN: Int32, _ isCompleted: Bool, _ responderOutput: UnidirectionalStream) -> UnidirectionalStream)? = nil
     
@@ -31,7 +31,7 @@ public final class TestRSocket: RSocket {
     public init(
         metadataPush: ((Data) -> ())? = nil,
         fireAndForget: ((Payload) -> ())? = nil,
-        requestResponse: ((Payload, UnidirectionalStream) -> Cancellable)? = nil,
+        requestResponse: ((Payload, Promise) -> Cancellable)? = nil,
         stream: ((Payload, Int32, UnidirectionalStream) -> Subscription)? = nil,
         channel: ((Payload, Int32, Bool, UnidirectionalStream) -> UnidirectionalStream)? = nil,
         file: StaticString = #file,
@@ -63,7 +63,7 @@ public final class TestRSocket: RSocket {
         fireAndForget(payload)
     }
     
-    public func requestResponse(payload: Payload, responderStream: UnidirectionalStream) -> Cancellable {
+    public func requestResponse(payload: Payload, responderStream: Promise) -> Cancellable {
         guard let requestResponse = requestResponse else {
             XCTFail("requestResponse not expected to be called ", file: file, line: line)
             return TestUnidirectionalStream()

--- a/Sources/RSocketTestUtilities/TestRSocket.swift
+++ b/Sources/RSocketTestUtilities/TestRSocket.swift
@@ -63,12 +63,12 @@ public final class TestRSocket: RSocket {
         fireAndForget(payload)
     }
     
-    public func requestResponse(payload: Payload, responderStream: Promise) -> Cancellable {
+    public func requestResponse(payload: Payload, responderPromise: Promise) -> Cancellable {
         guard let requestResponse = requestResponse else {
             XCTFail("requestResponse not expected to be called ", file: file, line: line)
             return TestUnidirectionalStream()
         }
-        return requestResponse(payload, responderStream)
+        return requestResponse(payload, responderPromise)
     }
     
     public func stream(payload: Payload, initialRequestN: Int32, responderStream: UnidirectionalStream) -> Subscription {

--- a/Sources/RSocketTestUtilities/TestUnidirectionalStream.swift
+++ b/Sources/RSocketTestUtilities/TestUnidirectionalStream.swift
@@ -85,7 +85,7 @@ public final class TestUnidirectionalStream {
     }
 }
 
-extension TestUnidirectionalStream: UnidirectionalStream {
+extension TestUnidirectionalStream: UnidirectionalStream, Promise {
     public func onNext(_ payload: Payload) {
         didReceiveEvent(.next(payload), callback: onNextCallback) {
             $0(payload)

--- a/Sources/RSocketTestUtilities/TestUnidirectionalStream.swift
+++ b/Sources/RSocketTestUtilities/TestUnidirectionalStream.swift
@@ -33,7 +33,7 @@ public final class TestUnidirectionalStream {
     /// if true, the current test will fail if an event is received but no callback is defined to handle the given event.
     /// Default is true.
     public var failOnUnexpectedEvent: Bool
-    public var onNextCallback: ((_ payload: Payload, _ isCompletion: Bool) -> ())?
+    public var onNextCallback: ((_ payload: Payload) -> ())?
     public var onErrorCallback: ((_ error: Error) -> ())?
     public var onCompleteCallback: (() -> ())?
     public var onCancelCallback: (() -> ())?
@@ -43,7 +43,7 @@ public final class TestUnidirectionalStream {
     private let line: UInt
     
     public init(
-        onNext: ((Payload, Bool) -> ())? = nil,
+        onNext: ((Payload) -> ())? = nil,
         onError: ((Error) -> ())? = nil,
         onComplete: (() -> ())? = nil,
         onCancel: (() -> ())? = nil,
@@ -86,9 +86,9 @@ public final class TestUnidirectionalStream {
 }
 
 extension TestUnidirectionalStream: UnidirectionalStream {
-    public func onNext(_ payload: Payload, isCompletion: Bool) {
-        didReceiveEvent(.next(payload, isCompletion: isCompletion), callback: onNextCallback) {
-            $0(payload, isCompletion)
+    public func onNext(_ payload: Payload) {
+        didReceiveEvent(.next(payload), callback: onNextCallback) {
+            $0(payload)
         }
     }
     public func onError(_ error: Error) {
@@ -124,7 +124,7 @@ extension TestUnidirectionalStream: UnidirectionalStream {
 extension TestUnidirectionalStream {
     public static func echo(to output: UnidirectionalStream) -> TestUnidirectionalStream {
         return TestUnidirectionalStream {
-            output.onNext($0, isCompletion: $1)
+            output.onNext($0)
         } onError: {
             output.onError($0)
         } onComplete: {

--- a/Tests/RSocketCorePerformanceTests/EndToEndTests.swift
+++ b/Tests/RSocketCorePerformanceTests/EndToEndTests.swift
@@ -157,7 +157,7 @@ class EndToEndTests: XCTestCase {
             }
             for _ in 0..<requestCount {
                 requestSemaphore.wait()
-                _ = requester.requestResponse(payload: helloWorld, responderStream: input)
+                _ = requester.requestResponse(payload: helloWorld, responderPromise: input)
             }
             self.wait(for: [request, response], timeout: 5)
         }

--- a/Tests/RSocketCoreTests/EndToEndTests.swift
+++ b/Tests/RSocketCoreTests/EndToEndTests.swift
@@ -228,7 +228,7 @@ class EndToEndTests: XCTestCase {
             XCTAssertEqual(payload, helloWorld)
             response.fulfill()
         }
-        _ = requester.requestResponse(payload: helloWorld, responderStream: input)
+        _ = requester.requestResponse(payload: helloWorld, responderPromise: input)
         self.wait(for: [request, response], timeout: 1)
     }
     func testRequestResponseFragmentation() throws {
@@ -254,7 +254,7 @@ class EndToEndTests: XCTestCase {
             XCTAssertEqual(payload, largePayload)
             response.fulfill()
         }
-        _ = requester.requestResponse(payload: largePayload, responderStream: input)
+        _ = requester.requestResponse(payload: largePayload, responderPromise: input)
         self.wait(for: [request, response], timeout: 1)
     }
     func testRequestResponseError() throws {
@@ -274,7 +274,7 @@ class EndToEndTests: XCTestCase {
             XCTAssertEqual(error, .applicationError(message: "I don't like your request"))
             response.fulfill()
         })
-        _ = requester.requestResponse(payload: helloWorld, responderStream: input)
+        _ = requester.requestResponse(payload: helloWorld, responderPromise: input)
         self.wait(for: [request, response], timeout: 1)
     }
     func testChannelEcho() throws {


### PR DESCRIPTION
### Motivation:
During implementing the adapters for ReactiveSwift and async/await and because of our efforts to standardize the implementation across languages, we noticed two things:
- `REQUEST_RESPONSE` streams have an implicit demand/request-n of 1 and should never send/receive any `REQUEST_N` frames
-  `REQUEST_RESPONSE` streams will always complete with the first payload/onNext and can't complete without a payload

However, the `RSocket.requestResponse(payload:responderStream:)` method does not model it like that and makes it possible to send/receive `REQUEST_N` frames and to receive `PAYLOAD` frames without the `isComplete` flag set.

### Modifications:

This PR adds a new protocol called `Promise`:
```swift
public protocol Promise: Cancellable {
    func onNext(_ payload: Payload)
}
```
it inherits from `Cancelable` and only defines one additional method `onNext(_:)` which only takes a `Payload`. 

The `requestResponse(payload:responderStream:) -> Cancellable` method on RSocket now takes a `Promise` instead of an `UnidirectionalStream` and the parameter is also renamed to `responderPromise`.

Furthermore, the `onNext(_:isComplete:)` method on `UnidirectionalStream` losses it's `isComplete` parameter.

Tests and ReactiveSwift adapter are also update. The ReactiveSwift adapter is now even a bit simpler and we could remove some assertions regarding REQUEST_N frames on a REQUEST_RESPONSE stream.

### Result:
It is no longer possible to send/receive `REQUEST_N` frames or complete a `REQUEST_RESPONSE` stream without a payload or to forget to complete it. 
In addition, `UnidirectionalStream` got simplified because it can now only be completed through the `onComplete()` method.