### PR TITLE
Requester API with Decoder/Encoder

### DIFF
--- a/Sources/Examples/TimerClient/main.swift
+++ b/Sources/Examples/TimerClient/main.swift
@@ -35,7 +35,7 @@ struct TimerClientExample: ParsableCommand {
         )
         
         let client = try bootstrap.connect(to: .init(url: url)).first()!.get()
-        try client.requester(RequestStream {
+        try client.requester.build(RequestStream {
             Encoder()
                 .encodeStaticMetadata("timer", using: RoutingEncoder())
             Decoder()

--- a/Sources/Examples/TwitterClient/main.swift
+++ b/Sources/Examples/TwitterClient/main.swift
@@ -38,7 +38,7 @@ struct TwitterClientExample: ParsableCommand {
         )
         
         let client = try bootstrap.connect(to: .init(url: url)).first()!.get()
-        try client.requester(RequestStream {
+        try client.requester.build(RequestStream {
             Encoder()
                 .encodeStaticMetadata("searchTweets", using: RoutingEncoder())
                 .mapData { (string: String) in 

--- a/Sources/Examples/VanillaClient/main.swift
+++ b/Sources/Examples/VanillaClient/main.swift
@@ -22,11 +22,11 @@ struct VanillaClientExample: ParsableCommand {
         
         let client = try bootstrap.connect(to: .init(host: host, port: port)).first()!.get()
 
-        let streamProducer = client.requester(
+        let streamProducer = client.requester.build(
             RequestStream(),
             request: Data()
         )
-        let requestProducer = client.requester(RequestResponse(), request: Data("HelloWorld".utf8))
+        let requestProducer = client.requester.build(RequestResponse(), request: Data("HelloWorld".utf8))
 
         streamProducer.logEvents(identifier: "stream1").take(first: 1).start()
         streamProducer.logEvents(identifier: "stream3").take(first: 10).start()

--- a/Sources/Examples/VanillaClient/main.swift
+++ b/Sources/Examples/VanillaClient/main.swift
@@ -22,8 +22,11 @@ struct VanillaClientExample: ParsableCommand {
         
         let client = try bootstrap.connect(to: .init(host: host, port: port)).first()!.get()
 
-        let streamProducer = client.requester.requestStream(payload: .empty)
-        let requestProducer = client.requester.requestResponse(payload: Payload(data: Data("HelloWorld".utf8)))
+        let streamProducer = client.requester(
+            RequestStream(),
+            request: Data()
+        )
+        let requestProducer = client.requester(RequestResponse(), request: Data("HelloWorld".utf8))
 
         streamProducer.logEvents(identifier: "stream1").take(first: 1).start()
         streamProducer.logEvents(identifier: "stream3").take(first: 10).start()

--- a/Sources/RSocketCore/Channel Handler/ConnectionEstablishment.swift
+++ b/Sources/RSocketCore/Channel Handler/ConnectionEstablishment.swift
@@ -44,27 +44,7 @@ public struct SetupInfo {
     /// Token used for client resume identification
     public let resumeIdentificationToken: Data?
 
-    /**
-     MIME Type for encoding of Metadata
-
-     This SHOULD be a US-ASCII string that includes the Internet media type specified in RFC 2045.
-     Many are registered with IANA such as CBOR.
-     Suffix rules MAY be used for handling layout.
-     For example, `application/x.netflix+cbor` or `application/x.reactivesocket+cbor` or `application/x.netflix+json`.
-     The string MUST NOT be null terminated.
-     */
-    public let metadataEncodingMimeType: String
-
-    /**
-     MIME Type for encoding of Data
-
-     This SHOULD be a US-ASCII string that includes the Internet media type specified in RFC 2045.
-     Many are registered with IANA such as CBOR.
-     Suffix rules MAY be used for handling layout.
-     For example, `application/x.netflix+cbor` or `application/x.reactivesocket+cbor` or `application/x.netflix+json`.
-     The string MUST NOT be null terminated.
-     */
-    public let dataEncodingMimeType: String
+    public let encoding: ConnectionEncoding
 
     /// Payload of this frame describing connection capabilities of the endpoint sending the Setup header
     public let payload: Payload
@@ -114,8 +94,10 @@ extension SetupInfo {
         self.timeBetweenKeepaliveFrames = setup.timeBetweenKeepaliveFrames
         self.maxLifetime = setup.maxLifetime
         self.resumeIdentificationToken = setup.resumeIdentificationToken
-        self.metadataEncodingMimeType = setup.metadataEncodingMimeType
-        self.dataEncodingMimeType = setup.dataEncodingMimeType
+        self.encoding = .init(
+            metadata: .init(rawValue: setup.metadataEncodingMimeType), 
+            data: .init(rawValue: setup.dataEncodingMimeType)
+        )
         self.payload = setup.payload
     }
 }

--- a/Sources/RSocketCore/Client/ClientBootstrap.swift
+++ b/Sources/RSocketCore/Client/ClientBootstrap.swift
@@ -21,6 +21,8 @@ public protocol ClientBootstrap {
     associatedtype Responder
     associatedtype Transport: TransportChannelHandler
     
+    var config: ClientConfiguration { get }
+    
     /// Creates a new connection to the given `endpoint`.
     /// - Parameters:
     ///   - endpoint: endpoint to connect to

--- a/Sources/RSocketCore/Client/ClientConfiguration.swift
+++ b/Sources/RSocketCore/Client/ClientConfiguration.swift
@@ -57,27 +57,6 @@ public struct ClientConfiguration {
         }
     }
     
-    /// encoding configuration of metadata and data which is send to the server during setup
-    public struct Encoding {
-        
-        /// default encoding uses `.octetStream` for metadata and data
-        public static let `default` = Encoding()
-        
-        /// MIME Type for encoding of Metadata
-        public var metadata: MIMEType
-        
-        /// MIME Type for encoding of Data
-        public var data: MIMEType
-        
-        public init(
-            metadata: MIMEType = .default,
-            data: MIMEType = .default
-        ) {
-            self.metadata = metadata
-            self.data = data
-        }
-    }
-    
     /// local fragmentation configuration which are **not** send to the server
     public struct Fragmentation {
         
@@ -109,14 +88,14 @@ public struct ClientConfiguration {
     public var timeout: Timeout
     
     /// encoding configuration of metadata and data which is send to the server during setup
-    public var encoding: Encoding
+    public var encoding: ConnectionEncoding
     
     /// local fragmentation configuration which are **not** send to the server
     public var fragmentation: Fragmentation
     
     public init(
         timeout: Timeout,
-        encoding: Encoding = .default,
+        encoding: ConnectionEncoding = .default,
         fragmentation: Fragmentation = .default
     ) {
         self.timeout = timeout

--- a/Sources/RSocketCore/DefaultRSocket.swift
+++ b/Sources/RSocketCore/DefaultRSocket.swift
@@ -29,6 +29,7 @@ fileprivate final class NoOpStream: UnidirectionalStream {
 
 /// An RSocket which rejects all incoming requests (requestResponse, stream and channel) and ignores metadataPush and fireAndForget events.
 internal struct DefaultRSocket: RSocket {
+    let encoding: ConnectionEncoding
     func metadataPush(metadata: Data) {}
     func fireAndForget(payload: Payload) {}
     func requestResponse(payload: Payload, responderStream: UnidirectionalStream) -> Cancellable {

--- a/Sources/RSocketCore/Extensions/Coder/Decoder/Decoder.swift
+++ b/Sources/RSocketCore/Extensions/Coder/Decoder/Decoder.swift
@@ -38,5 +38,15 @@ public struct Decoder: DecoderProtocol {
     }
 }
 
+extension DecoderProtocol where Metadata == Void {
+    @inlinable
+    public mutating func decode(
+        _ payload: Payload,
+        encoding: ConnectionEncoding
+    ) throws -> Data {
+        try decode(payload, encoding: encoding).1
+    }
+}
+
 /// Namespace for types conforming to the ``DecoderProtocol`` protocol
 public enum Decoders {}

--- a/Sources/RSocketCore/Extensions/Coder/Encoder/Encoder.swift
+++ b/Sources/RSocketCore/Extensions/Coder/Encoder/Encoder.swift
@@ -36,5 +36,15 @@ public struct Encoder: EncoderProtocol {
     }
 }
 
+extension EncoderProtocol where Metadata == Void {
+    @inlinable
+    public mutating func encode(
+        _ data: Data,
+        encoding: ConnectionEncoding
+    ) throws -> Payload {
+        try encode(metadata: (), data: data, encoding: encoding)
+    }
+}
+
 /// Namespace for types conforming to the ``EncoderProtocol`` protocol
 public enum Encoders {}

--- a/Sources/RSocketCore/Extensions/Coder/Encoder/OctetStreamMetadataEncoder.swift
+++ b/Sources/RSocketCore/Extensions/Coder/Encoder/OctetStreamMetadataEncoder.swift
@@ -15,16 +15,25 @@
  */
 
 import Foundation
+import NIO
 
-public protocol RSocket {
-    var encoding: ConnectionEncoding { get }
-    func metadataPush(metadata: Data)
-    
-    func fireAndForget(payload: Payload)
-    
-    func requestResponse(payload: Payload, responderStream: UnidirectionalStream) -> Cancellable
-    
-    func stream(payload: Payload, initialRequestN: Int32, responderStream: UnidirectionalStream) -> Subscription
-    
-    func channel(payload: Payload, initialRequestN: Int32, isCompleted: Bool, responderStream: UnidirectionalStream) -> UnidirectionalStream
+public struct OctetStreamMetadataEncoder: MetadataEncoder {
+    public typealias Metadata = Data?
+
+    @inlinable
+    public init() {}
+
+    @inlinable
+    public var mimeType: MIMEType { .applicationOctetStream }
+
+    @inlinable
+    public func encode(_ metadata: Data?, into buffer: inout ByteBuffer) throws {
+        guard let metadata = metadata else { return }
+        buffer.writeData(metadata)
+    }
+}
+
+extension MetadataEncoder where Self == OctetStreamMetadataEncoder {
+    @inlinable
+    public static var octetStream: Self { .init() }
 }

--- a/Sources/RSocketCore/Extensions/RootCompositeMetadataDecoder.swift
+++ b/Sources/RSocketCore/Extensions/RootCompositeMetadataDecoder.swift
@@ -25,10 +25,10 @@ public struct RootCompositeMetadataDecoder: MetadataDecoder {
     public var mimeType: MIMEType { .messageXRSocketCompositeMetadataV0 }
     
     @usableFromInline
-    internal let mimeTypeDecoder: MIMETypeEncoder
+    internal let mimeTypeDecoder: MIMETypeDecoder
     
     @inlinable
-    public init(mimeTypeDecoder: MIMETypeEncoder = MIMETypeEncoder()) {
+    public init(mimeTypeDecoder: MIMETypeDecoder = MIMETypeDecoder()) {
         self.mimeTypeDecoder = mimeTypeDecoder
     }
     

--- a/Sources/RSocketCore/Extensions/RoutingDecoder.swift
+++ b/Sources/RSocketCore/Extensions/RoutingDecoder.swift
@@ -18,7 +18,10 @@ import NIO
 
 public struct RoutingDecoder: MetadataDecoder {
     public typealias Metadata = RouteMetadata
-    
+
+    @inlinable
+    public init() {}
+
     @inlinable
     public var mimeType: MIMEType { .messageXRSocketRoutingV0 }
     

--- a/Sources/RSocketCore/Extensions/RoutingEncoder.swift
+++ b/Sources/RSocketCore/Extensions/RoutingEncoder.swift
@@ -18,6 +18,9 @@ import NIO
 
 public struct RoutingEncoder: MetadataEncoder {
     public typealias Metadata = RouteMetadata
+
+    @inlinable
+    public init() {}
     
     @inlinable
     public var mimeType: MIMEType { .messageXRSocketRoutingV0 }

--- a/Sources/RSocketCore/RequestDescription.swift
+++ b/Sources/RSocketCore/RequestDescription.swift
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
+import Foundation
+
 public struct MetadataPush<Metadata> {
     public let encoder: AnyMetadataEncoder<Metadata>
 }
 
 extension MetadataPush {
+    @inlinable
+    public init() where Metadata == Data? {
+        self.init(using: OctetStreamMetadataEncoder())
+    }
     @inlinable
     public init<Encoder>(
         using metadataEncoder: Encoder
@@ -30,7 +36,7 @@ extension MetadataPush {
     public init<Encoder>(
         @CompositeMetadataEncoderBuilder _ makeEncoder: () -> Encoder
     ) where 
-    Encoder: MetadataEncoder, 
+    Encoder: MetadataEncoder,
     Encoder.Metadata == Metadata
     {
         encoder = makeEncoder().eraseToAnyMetadataEncoder()
@@ -42,6 +48,12 @@ public struct FireAndForget<Request> {
 }
 
 extension FireAndForget {
+    @inlinable
+    public init() where Request == Data {
+        self.init { Encoder() }
+    }
+
+    @inlinable
     public init<Encoder>(
         @EncoderBuilder _ makeEncoder: () -> Encoder
     ) where 
@@ -59,6 +71,11 @@ public struct RequestResponse<Request, Response> {
 }
 
 extension RequestResponse {
+    @inlinable
+    public init() where Request == Data, Response == Data {
+        self.init { Coder() }
+    }
+
     @inlinable
     public init<Encoder, Decoder>(
         @CoderBuilder _ makeCoder: () -> Coder<Decoder, Encoder>
@@ -79,6 +96,11 @@ public struct RequestStream<Request, Response> {
 
 extension RequestStream {
     @inlinable
+    public init() where Request == Data, Response == Data {
+        self.init { Coder() }
+    }
+
+    @inlinable
     public init<Encoder, Decoder>(
         @CoderBuilder _ makeCoder: () -> Coder<Decoder, Encoder>
     ) where
@@ -97,6 +119,11 @@ public struct RequestChannel<Request, Response> {
 }
 
 extension RequestChannel {
+    @inlinable
+    public init() where Request == Data, Response == Data {
+        self.init { Coder() }
+    }
+
     @inlinable
     public init<Encoder, Decoder>(
         @CoderBuilder _ makeCoder: () -> Coder<Decoder, Encoder>

--- a/Sources/RSocketCore/Streams/Requester.swift
+++ b/Sources/RSocketCore/Streams/Requester.swift
@@ -18,6 +18,7 @@ import Foundation
 import NIO
 
 internal final class Requester {
+    internal let encoding: ConnectionEncoding
     private let sendFrame: (Frame) -> Void
     private let eventLoop: EventLoop
     private var streamIdGenerator: StreamIDGenerator
@@ -26,11 +27,13 @@ internal final class Requester {
 
     internal init(
         streamIdGenerator: StreamIDGenerator,
+        encoding: ConnectionEncoding,
         eventLoop: EventLoop,
         sendFrame: @escaping (Frame) -> Void,
         lateFrameHandler: ((Frame) -> ())? = nil
     ) {
         self.streamIdGenerator = streamIdGenerator
+        self.encoding = encoding
         self.eventLoop = eventLoop
         self.sendFrame = sendFrame
         self.lateFrameHandler = lateFrameHandler

--- a/Sources/RSocketCore/Streams/Responder.swift
+++ b/Sources/RSocketCore/Streams/Responder.swift
@@ -23,12 +23,12 @@ internal final class Responder {
     private let eventLoop: EventLoop
     private let lateFrameHandler: ((Frame) -> ())?
     internal init(
-        responderSocket: RSocket? = nil,
+        responderSocket: RSocket,
         eventLoop: EventLoop,
         sendFrame: @escaping (Frame) -> Void,
         lateFrameHandler: ((Frame) -> ())? = nil
     ) {
-        self.responderSocket = responderSocket ?? DefaultRSocket()
+        self.responderSocket = responderSocket
         self.sendFrame = sendFrame
         self.eventLoop = eventLoop
         self.lateFrameHandler = lateFrameHandler

--- a/Sources/RSocketNIOChannel/ClientBootstrap.swift
+++ b/Sources/RSocketNIOChannel/ClientBootstrap.swift
@@ -21,7 +21,7 @@ import RSocketCore
 final public class ClientBootstrap<Transport: TransportChannelHandler> {
     private let group: EventLoopGroup
     private let bootstrap: NIO.ClientBootstrap
-    private let config: ClientConfiguration
+    public let config: ClientConfiguration
     private let transport: Transport
     private let sslContext: NIOSSLContext?
 

--- a/Sources/RSocketReactiveSwift/Requester.swift
+++ b/Sources/RSocketReactiveSwift/Requester.swift
@@ -27,18 +27,18 @@ internal struct RequesterAdapter {
 }
 
 extension RequesterAdapter: RequesterRSocket {
-    func callAsFunction<Metadata>(_ metadataPush: MetadataPush<Metadata>, metadata: Metadata) throws {
+    func execute<Metadata>(_ metadataPush: MetadataPush<Metadata>, metadata: Metadata) throws {
         let metadata = try metadataPush.encoder.encode(metadata)
         self.metadataPush(metadata: metadata)
     }
 
-    func callAsFunction<Request>(_ fireAndForget: FireAndForget<Request>, request: Request) throws {
+    func execute<Request>(_ fireAndForget: FireAndForget<Request>, request: Request) throws {
         var encoder = fireAndForget.encoder
         let payload = try encoder.encode(request, encoding: encoding)
         self.fireAndForget(payload: payload)
     }
 
-    func callAsFunction<Request, Response>(
+    func build<Request, Response>(
         _ requestResponse: RequestResponse<Request, Response>,
         request: Request
     ) -> SignalProducer<Response, Swift.Error> {
@@ -52,7 +52,7 @@ extension RequesterAdapter: RequesterRSocket {
         }.flatten(.latest)
     }
 
-    func callAsFunction<Request, Response>(
+    func build<Request, Response>(
         _ requestStream: RequestStream<Request, Response>,
         request: Request
     ) -> SignalProducer<Response, Swift.Error> {
@@ -66,7 +66,7 @@ extension RequesterAdapter: RequesterRSocket {
         }.flatten(.latest)
     }
 
-    func callAsFunction<Request, Response>(
+    func build<Request, Response>(
         _ requestChannel: RequestChannel<Request, Response>,
         initialRequest: Request,
         producer: SignalProducer<Request, Swift.Error>?

--- a/Sources/RSocketReactiveSwift/Requester.swift
+++ b/Sources/RSocketReactiveSwift/Requester.swift
@@ -18,11 +18,77 @@ import ReactiveSwift
 import RSocketCore
 import Foundation
 
-internal struct RequesterAdapter: RSocket {
+internal struct RequesterAdapter {
     internal let requester: RSocketCore.RSocket
     
     internal init(requester: RSocketCore.RSocket) {
         self.requester = requester
+    }
+}
+
+extension RequesterAdapter: RequesterRSocket {
+    func callAsFunction<Metadata>(_ metadataPush: MetadataPush<Metadata>, metadata: Metadata) throws {
+        let metadata = try metadataPush.encoder.encode(metadata)
+        self.metadataPush(metadata: metadata)
+    }
+
+    func callAsFunction<Request>(_ fireAndForget: FireAndForget<Request>, request: Request) throws {
+        var encoder = fireAndForget.encoder
+        let payload = try encoder.encode(request, encoding: encoding)
+        self.fireAndForget(payload: payload)
+    }
+
+    func callAsFunction<Request, Response>(
+        _ requestResponse: RequestResponse<Request, Response>,
+        request: Request
+    ) -> SignalProducer<Response, Swift.Error> {
+        SignalProducer { () throws -> SignalProducer<Response, Swift.Error> in
+            var encoder = requestResponse.encoder
+            var decoder = requestResponse.decoder
+            let payload = try encoder.encode(request, encoding: encoding)
+            return self.requestResponse(payload: payload).attemptMap { response in
+                try decoder.decode(response, encoding: encoding)
+            }
+        }.flatten(.latest)
+    }
+
+    func callAsFunction<Request, Response>(
+        _ requestStream: RequestStream<Request, Response>,
+        request: Request
+    ) -> SignalProducer<Response, Swift.Error> {
+        SignalProducer { () throws -> SignalProducer<Response, Swift.Error> in
+            var encoder = requestStream.encoder
+            var decoder = requestStream.decoder
+            let payload = try encoder.encode(request, encoding: encoding)
+            return self.requestStream(payload: payload).attemptMap { response in
+                try decoder.decode(response, encoding: encoding)
+            }
+        }.flatten(.latest)
+    }
+
+    func callAsFunction<Request, Response>(
+        _ requestChannel: RequestChannel<Request, Response>,
+        initialRequest: Request,
+        producer: SignalProducer<Request, Swift.Error>?
+    ) -> SignalProducer<Response, Swift.Error> {
+        SignalProducer { () throws -> SignalProducer<Response, Swift.Error> in
+            var encoder = requestChannel.encoder
+            var decoder = requestChannel.decoder
+            let payload = try encoder.encode(initialRequest, encoding: encoding)
+            let payloadProducer = producer?.attemptMap { data in
+                try encoder.encode(data, encoding: encoding)
+            }
+            return self.requestChannel(payload: payload, payloadProducer: payloadProducer).attemptMap{ response in
+                try decoder.decode(response, encoding: encoding)
+            }
+        }.flatten(.latest)
+    }
+}
+
+
+extension RequesterAdapter {
+    internal var encoding: ConnectionEncoding {
+        requester.encoding
     }
     
     internal func metadataPush(metadata: Data) {

--- a/Sources/RSocketReactiveSwift/RequesterRSocket.swift
+++ b/Sources/RSocketReactiveSwift/RequesterRSocket.swift
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ReactiveSwift
+import RSocketCore
+
+public protocol RequesterRSocket {
+    func callAsFunction<Metadata>(_ metadataPush: MetadataPush<Metadata>, metadata: Metadata) throws
+
+    func callAsFunction<Request>(_ fireAndForget: FireAndForget<Request>, request: Request) throws
+
+    func callAsFunction<Request, Response>(
+        _ requestResponse: RequestResponse<Request, Response>,
+        request: Request
+    ) -> SignalProducer<Response, Swift.Error>
+
+    func callAsFunction<Request, Response>(
+        _ requestStream: RequestStream<Request, Response>,
+        request: Request
+    ) -> SignalProducer<Response, Swift.Error>
+
+    func callAsFunction<Request, Response>(
+        _ requestChannel: RequestChannel<Request, Response>,
+        initialRequest: Request,
+        producer: SignalProducer<Request, Swift.Error>?
+    ) -> SignalProducer<Response, Swift.Error>
+}

--- a/Sources/RSocketReactiveSwift/RequesterRSocket.swift
+++ b/Sources/RSocketReactiveSwift/RequesterRSocket.swift
@@ -18,21 +18,21 @@ import ReactiveSwift
 import RSocketCore
 
 public protocol RequesterRSocket {
-    func callAsFunction<Metadata>(_ metadataPush: MetadataPush<Metadata>, metadata: Metadata) throws
+    func execute<Metadata>(_ metadataPush: MetadataPush<Metadata>, metadata: Metadata) throws
 
-    func callAsFunction<Request>(_ fireAndForget: FireAndForget<Request>, request: Request) throws
+    func execute<Request>(_ fireAndForget: FireAndForget<Request>, request: Request) throws
 
-    func callAsFunction<Request, Response>(
+    func build<Request, Response>(
         _ requestResponse: RequestResponse<Request, Response>,
         request: Request
     ) -> SignalProducer<Response, Swift.Error>
 
-    func callAsFunction<Request, Response>(
+    func build<Request, Response>(
         _ requestStream: RequestStream<Request, Response>,
         request: Request
     ) -> SignalProducer<Response, Swift.Error>
 
-    func callAsFunction<Request, Response>(
+    func build<Request, Response>(
         _ requestChannel: RequestChannel<Request, Response>,
         initialRequest: Request,
         producer: SignalProducer<Request, Swift.Error>?

--- a/Sources/RSocketReactiveSwift/Responder.swift
+++ b/Sources/RSocketReactiveSwift/Responder.swift
@@ -18,11 +18,14 @@ import ReactiveSwift
 import RSocketCore
 import Foundation
 
-internal struct ResponderAdapter: RSocketCore.RSocket {
-    private let responder: RSocket
+internal struct ResponderAdapter: RSocketCore.RSocket {    
+    private let responder: ResponderRSocket
+    
+    internal var encoding: ConnectionEncoding
 
-    internal init(responder: RSocket) {
+    internal init(responder: ResponderRSocket, encoding: ConnectionEncoding) {
         self.responder = responder
+        self.encoding = encoding
     }
 
     func metadataPush(metadata: Data) {

--- a/Sources/RSocketReactiveSwift/ResponderRSocket.swift
+++ b/Sources/RSocketReactiveSwift/ResponderRSocket.swift
@@ -19,7 +19,7 @@ import ReactiveSwift
 import RSocketCore
 import Foundation
 
-public protocol RSocket {
+public protocol ResponderRSocket {
     func metadataPush(metadata: Data)
     func fireAndForget(payload: Payload)
     func requestResponse(payload: Payload) -> SignalProducer<Payload, Swift.Error>

--- a/Sources/RSocketTSChannel/ClientBootstrap.swift
+++ b/Sources/RSocketTSChannel/ClientBootstrap.swift
@@ -25,7 +25,7 @@ import RSocketCore
 final public class ClientBootstrap<Transport: TransportChannelHandler> {
     private let group = NIOTSEventLoopGroup()
     private let bootstrap: NIOTSConnectionBootstrap
-    private let config: ClientConfiguration
+    public let config: ClientConfiguration
     private let transport: Transport
     private let tlsOptions: NWProtocolTLS.Options?
     public init(

--- a/Sources/RSocketTestUtilities/TestRSocket.swift
+++ b/Sources/RSocketTestUtilities/TestRSocket.swift
@@ -19,6 +19,7 @@ import NIO
 import RSocketCore
 
 public final class TestRSocket: RSocket {
+    public var encoding: ConnectionEncoding
     public var metadataPush: ((Data) -> ())? = nil
     public var fireAndForget: ((_ payload: Payload) -> ())? = nil
     public var requestResponse: ((_ payload: Payload, _ responderOutput: UnidirectionalStream) -> Cancellable)? = nil
@@ -34,9 +35,11 @@ public final class TestRSocket: RSocket {
         requestResponse: ((Payload, UnidirectionalStream) -> Cancellable)? = nil,
         stream: ((Payload, Int32, UnidirectionalStream) -> Subscription)? = nil,
         channel: ((Payload, Int32, Bool, UnidirectionalStream) -> UnidirectionalStream)? = nil,
+        encoding: ConnectionEncoding = .default,
         file: StaticString = #file,
         line: UInt = #line
     ) {
+        self.encoding = encoding
         self.metadataPush = metadataPush
         self.fireAndForget = fireAndForget
         self.requestResponse = requestResponse

--- a/Tests/RSocketCoreTests/EndToEndTests.swift
+++ b/Tests/RSocketCoreTests/EndToEndTests.swift
@@ -157,8 +157,8 @@ class EndToEndTests: XCTestCase {
         let server = makeServerBootstrap(shouldAcceptClient: { clientInfo in
             XCTAssertEqual(clientInfo.timeBetweenKeepaliveFrames, Int32(setup.timeout.timeBetweenKeepaliveFrames))
             XCTAssertEqual(clientInfo.maxLifetime, Int32(setup.timeout.maxLifetime))
-            XCTAssertEqual(clientInfo.metadataEncodingMimeType, setup.encoding.metadata.rawValue)
-            XCTAssertEqual(clientInfo.dataEncodingMimeType, setup.encoding.data.rawValue)
+            XCTAssertEqual(clientInfo.encoding.metadata, setup.encoding.metadata)
+            XCTAssertEqual(clientInfo.encoding.data, setup.encoding.data)
             clientDidConnect.fulfill()
             return .accept
         })

--- a/Tests/RSocketReactiveSwiftTests/RSocketReactiveSwiftTests.swift
+++ b/Tests/RSocketReactiveSwiftTests/RSocketReactiveSwiftTests.swift
@@ -49,7 +49,7 @@ final class RSocketReactiveSwiftTests: XCTestCase {
             XCTAssertEqual(data, metadata)
         })
         let (_, client) = setup(server: serverResponder)
-        try client.requester(MetadataPush(), metadata: metadata)
+        try client.requester.execute(MetadataPush(), metadata: metadata)
         self.wait(for: [didReceiveRequest], timeout: 0.1)
     }
     func testFireAndForget() throws {
@@ -59,7 +59,7 @@ final class RSocketReactiveSwiftTests: XCTestCase {
             XCTAssertEqual(payload, "Hello World")
         })
         let (_, client) = setup(server: serverResponder)
-        try client.requester(FireAndForget(), request: "Hello World")
+        try client.requester.execute(FireAndForget(), request: "Hello World")
         self.wait(for: [didReceiveRequest], timeout: 0.1)
     }
     func testRequestResponse() {
@@ -76,7 +76,7 @@ final class RSocketReactiveSwiftTests: XCTestCase {
             }
         })
         let (_, client) = setup(server: serverResponder)
-        let disposable = client.requester(
+        let disposable = client.requester.build(
             RequestResponse(),
             request: "Hello World"
         ).startWithSignal { signal, _ in
@@ -105,7 +105,7 @@ final class RSocketReactiveSwiftTests: XCTestCase {
             }
         })
         let (_, client) = setup(server: serverResponder)
-        let disposable = client.requester(
+        let disposable = client.requester.build(
             RequestResponse(),
             request: "Hello World"
         ).startWithSignal { signal, _ in
@@ -139,7 +139,7 @@ final class RSocketReactiveSwiftTests: XCTestCase {
             }
         })
         let (_, client) = setup(server: serverResponder)
-        let disposable = client.requester(RequestStream(), request: "Hello World").startWithSignal { signal, _ in
+        let disposable = client.requester.build(RequestStream(), request: "Hello World").startWithSignal { signal, _ in
             signal.flatMapError({ error in
                 XCTFail("\(error)")
                 return .empty
@@ -185,7 +185,7 @@ final class RSocketReactiveSwiftTests: XCTestCase {
             }
         })
         let (_, client) = setup(server: serverResponder)
-        let disposable = client.requester(RequestChannel(), initialRequest: "Hello Responder", producer: .init({ observer, _ in
+        let disposable = client.requester.build(RequestChannel(), initialRequest: "Hello Responder", producer: .init({ observer, _ in
             requesterDidSendChannelMessages.fulfill()
             observer.send(value: "Hello")
             observer.send(value: "from")
@@ -229,7 +229,7 @@ final class RSocketReactiveSwiftTests: XCTestCase {
             }
         })
         let (_, client) = setup(server: serverResponder)
-        let disposable = client.requester(RequestResponse(), request: "Hello World").startWithSignal { signal, _ -> Disposable? in
+        let disposable = client.requester.build(RequestResponse(), request: "Hello World").startWithSignal { signal, _ -> Disposable? in
             didStartRequestSignal.fulfill()
             return signal.flatMapError({ error -> Signal<Data, Never> in
                 XCTFail("\(error)")
@@ -258,7 +258,7 @@ final class RSocketReactiveSwiftTests: XCTestCase {
             }
         })
         let (_, client) = setup(server: serverResponder)
-        let disposable = client.requester(RequestStream(), request: "Hello World").startWithSignal { signal, _ -> Disposable? in
+        let disposable = client.requester.build(RequestStream(), request: "Hello World").startWithSignal { signal, _ -> Disposable? in
             didStartRequestSignal.fulfill()
             return signal.flatMapError({ error -> Signal<Data, Never> in
                 XCTFail("\(error)")
@@ -303,7 +303,7 @@ final class RSocketReactiveSwiftTests: XCTestCase {
         let requesterDidStartListeningChannelMessages = expectation(description: "responder did start listening to channel messages")
         let payloadProducerLifetimeEnded = expectation(description: "payload producer lifetime ended")
         let requesterDidStartPayloadProducer = expectation(description: "requester did start payload producer")
-        let disposable = client.requester(RequestChannel(), initialRequest: "Hello", producer: .init({ observer, lifetime in
+        let disposable = client.requester.build(RequestChannel(), initialRequest: "Hello", producer: .init({ observer, lifetime in
             requesterDidStartPayloadProducer.fulfill()
             lifetime.observeEnded {
                 _ = observer

--- a/Tests/RSocketReactiveSwiftTests/TestDemultiplexer.swift
+++ b/Tests/RSocketReactiveSwiftTests/TestDemultiplexer.swift
@@ -48,11 +48,13 @@ extension TestDemultiplexer {
         serverResponder: RSocketCore.RSocket?,
         clientResponder: RSocketCore.RSocket?
     ) -> (server: TestDemultiplexer, client: TestDemultiplexer) {
+        let serverResponder = serverResponder ?? DefaultRSocket(encoding: .default)
+        let clientResponder = clientResponder ?? DefaultRSocket(encoding: .default)
         var client: TestDemultiplexer!
         let eventLoop = EmbeddedEventLoop()
         let server = TestDemultiplexer(
             connectionSide: .server,
-            requester: .init(streamIdGenerator: .server, eventLoop: eventLoop, sendFrame: { frame in
+            requester: .init(streamIdGenerator: .server, encoding: .default, eventLoop: eventLoop, sendFrame: { frame in
                 client.receiveFrame(frame: frame)
             }),
             responder: .init(responderSocket: serverResponder, eventLoop: eventLoop, sendFrame: { frame in
@@ -60,7 +62,7 @@ extension TestDemultiplexer {
             }))
         client = TestDemultiplexer(
             connectionSide: .client,
-            requester: .init(streamIdGenerator: .client, eventLoop: eventLoop, sendFrame: { frame in
+            requester: .init(streamIdGenerator: .client, encoding: .default, eventLoop: eventLoop, sendFrame: { frame in
                 server.receiveFrame(frame: frame)
             }),
             responder: .init(responderSocket: clientResponder, eventLoop: eventLoop, sendFrame: { frame in

--- a/Tests/RSocketReactiveSwiftTests/TestRSocket.swift
+++ b/Tests/RSocketReactiveSwiftTests/TestRSocket.swift
@@ -19,7 +19,7 @@ import ReactiveSwift
 import Foundation
 import RSocketReactiveSwift
 
-final class TestRSocket: RSocketReactiveSwift.RSocket {
+final class TestRSocket: RSocketReactiveSwift.ResponderRSocket {
     var metadataPushCallback: (Data) -> ()
     var fireAndForgetCallback: (Payload) -> ()
     var requestResponseCallback: (Payload) -> SignalProducer<Payload, Swift.Error>


### PR DESCRIPTION
This PR makes it possible to use the new Decoder/Encoder Pipeline in the ReactiveSwift Requester API.

### Motivation:

Make it easy to execute strongly typed requests.  

### Modifications:

- add `RequesterRSocket` protocol and conform RequesterAdapter to it:
```swift
public protocol RequesterRSocket {
    func execute<Metadata>(_ metadataPush: MetadataPush<Metadata>, metadata: Metadata) throws

    func execute<Request>(_ fireAndForget: FireAndForget<Request>, request: Request) throws

    func build<Request, Response>(
        _ requestResponse: RequestResponse<Request, Response>,
        request: Request
    ) -> SignalProducer<Response, Swift.Error>

    func build<Request, Response>(
        _ requestStream: RequestStream<Request, Response>,
        request: Request
    ) -> SignalProducer<Response, Swift.Error>

    func build<Request, Response>(
        _ requestChannel: RequestChannel<Request, Response>,
        initialRequest: Request,
        producer: SignalProducer<Request, Swift.Error>?
    ) -> SignalProducer<Response, Swift.Error>
}
```
- remove old request API because the new can do everything the old could.
- update examples and tests to use the new API

### Result:

We can now easily make request which use RSocket extensions e.g. CompositeMetadata or Routing.


### Discussion

#### method names build & execute 
The new requester methods for `MetadataPush` and `FireAndForget` are called `execute` because they start the work immediately. The methods for `RequestResponse`, `RequestStream` and `RequestChannel` are called `build` because they only start the work after the returned signal producer is started. This inconstancy is due to the limitation that we can't observe the progress of `FireAndForget` or `MetadataPush` streams. We may want to change that in the future so we can at least observe if the frame is flushed to the operating system. However, we can never say for sure that a `FireAndForget` or `MetadataPush` frame is actually received. This is by design of the protocol.

One could argue that this can be easily seen by the return types of those methods. The `execute` methods does not return anything and the `build` methods returns `SignalProducer`s, also know as a "cold signal". We would like to hear other opinions on that. If this is clear without the method name we could use just one method name or drop it all together by using `callAsFunction`.

#### callAsFunction
The first prototype used `callAsFunction` instead of `build`/`execute`. This makes the call site a bit shorter because we can drop the method name and use the `Requester` as if it is a function. After a discussion with @nkristek we decided that we want to give them a name initially because of the inconsistent start behavior between  `MetadataPush`/`FireAndForget` and `RequestResponse`/`RequestStream`/`RequestChannel`. Otherwise I think it would be nice to use `callAsFunction` here.