### PR TITLE
intoduces dispose api

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,12 +25,10 @@ jobs:
         
     - name: Test on macOS
       run: >
-        xcodebuild test
-        -scheme RSocket-Package
-        -parallelizeTargets
-        -skip-testing:RSocketCorePerformanceTests
-        -parallel-testing-enabled
-        -destination 'platform=macOS'
+        swift test
+        --parallel
+        --enable-test-discovery
+        --filter="^((?!(Performance)).)*\..*$"
         
   performance-tests-on-macOS:
     runs-on: macos-11

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,15 +13,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
         
-    - name: Test on iOS Simulator
-      run: >
-        xcodebuild test
-        -scheme RSocket-Package
-        -parallelizeTargets
-        -skip-testing:RSocketCorePerformanceTests
-        -parallel-testing-enabled
-        -sdk:iphonesimulator
-        -destination:'platform=iOS Simulator,name=iPhone 12'
+#    - name: Test on iOS Simulator
+#      run: >
+#        xcodebuild test
+#        -scheme RSocket-Package
+#        -parallelizeTargets
+#        -skip-testing:RSocketCorePerformanceTests
+#        -parallel-testing-enabled
+#        -sdk:iphonesimulator
+#        -destination:'platform=iOS Simulator,name=iPhone 12'
         
     - name: Test on macOS
       run: >

--- a/Sources/RSocketCore/Client/CoreClient.swift
+++ b/Sources/RSocketCore/Client/CoreClient.swift
@@ -23,17 +23,13 @@ public class CoreClient: Client {
         self.requester = requester
         self.channel = channel
     }
+    /// This method help to close channel connection.
+    /// - Returns: EventLoopFuture<Void> as a closeFuture
+    public func shutDown() -> EventLoopFuture<Void> {
+        return channel.close()
+    }
     deinit {
-        // checking if channel is active
-        if channel.isActive {
-            channel.close().whenComplete { [weak self] result in
-                guard let self = self else {return}
-                // after closing connection checking for error in result
-                if case .failure(let error)  = result {
-                    // passing to fireErrorCaught() method to notify
-                    self.channel.pipeline.fireErrorCaught(error)
-                }
-            }
-        }
+        // if chanel is active Need to close channel manually
+        assert(!channel.isActive, "Channel is active close channel manually")
     }
 }

--- a/Sources/RSocketCore/Client/CoreClient.swift
+++ b/Sources/RSocketCore/Client/CoreClient.swift
@@ -25,7 +25,7 @@ public class CoreClient: Client {
     }
     /// This method help to close channel connection.
     /// - Returns: EventLoopFuture<Void> as a closeFuture
-    public func shutDown() -> EventLoopFuture<Void> {
+    public func shutdown() -> EventLoopFuture<Void> {
         return channel.close()
     }
     deinit {

--- a/Sources/RSocketNIOChannel/ClientBootstrap.swift
+++ b/Sources/RSocketNIOChannel/ClientBootstrap.swift
@@ -96,10 +96,11 @@ extension ClientBootstrap: RSocketCore.ClientBootstrap {
                 return requesterPromise.futureResult }
             .map(CoreClient.init)
     }
-    
-    /*This method help to close channel connection
-     if want to hold thread and want to wait for close connection
-     use closeFuture.wait()*/
+    /**
+     This method help to close channel connection
+     if want to hold thread and want to wait for close connection.
+     - Returns: Future object so you can call  wait() for get connection closed.
+     **/
     public func dispose()-> EventLoopFuture<Void>?{
         guard let channel = self.channel else{return nil}
         channel.close(promise: nil)

--- a/Sources/RSocketNIOChannel/ClientBootstrap.swift
+++ b/Sources/RSocketNIOChannel/ClientBootstrap.swift
@@ -97,7 +97,7 @@ extension ClientBootstrap: RSocketCore.ClientBootstrap {
             .map(CoreClient.init)
     }
     /**
-     This method help to close channel connection
+     This method help to close socket channel connection
      if want to hold thread and want to wait for close connection.
      - Returns: Future object so you can call  wait() for get connection closed.
      **/

--- a/Sources/RSocketReactiveSwift/Client/ReactiveSwiftClient.swift
+++ b/Sources/RSocketReactiveSwift/Client/ReactiveSwiftClient.swift
@@ -16,6 +16,7 @@
 
 import RSocketCore
 import ReactiveSwift
+import NIOCore
 
 public struct ReactiveSwiftClient: Client {
     private let coreClient: CoreClient
@@ -24,6 +25,18 @@ public struct ReactiveSwiftClient: Client {
 
     public init(_ coreClient: CoreClient) {
         self.coreClient = coreClient
+    }
+    /// This method help to close channel connection.
+    /// if want to hold thread and want to wait for close connection use closeFuture.wait()
+    /// - Returns: EventLoopFuture<Void> as a closeFuture
+    public func dispose()-> EventLoopFuture<Void>? {
+        coreClient.channel.close(promise: nil)
+        return coreClient.channel.closeFuture
+    }
+    /// This method help to get channel current state
+    /// - Returns:true if channel is disposed or in-active
+    public var isDisposed: Bool {
+        return !coreClient.channel.isActive
     }
 }
 

--- a/Sources/RSocketReactiveSwift/Client/ReactiveSwiftClient.swift
+++ b/Sources/RSocketReactiveSwift/Client/ReactiveSwiftClient.swift
@@ -30,7 +30,7 @@ public struct ReactiveSwiftClient: Client {
     /// - Returns: SignalProducer<Void, Swift.Error> to represent task result
     public func shutdown() -> SignalProducer<Void, Swift.Error> {
         SignalProducer { observer, _ in
-            coreClient.shutDown().whenComplete { result in
+            coreClient.shutdown().whenComplete { result in
                 switch result {
                 case let .success(client):
                     observer.send(value: client)

--- a/Sources/RSocketReactiveSwift/Client/ReactiveSwiftClient.swift
+++ b/Sources/RSocketReactiveSwift/Client/ReactiveSwiftClient.swift
@@ -43,7 +43,7 @@ public struct ReactiveSwiftClient: Client {
     }
     /// This method help to get channel current state
     /// - Returns:true if channel is disposed or in-active
-    public var isDisposed: Bool {
+    internal var isDisposed: Bool {
         return !coreClient.channel.isActive
     }
 }

--- a/Sources/RSocketTSChannel/ClientBootstrap.swift
+++ b/Sources/RSocketTSChannel/ClientBootstrap.swift
@@ -82,10 +82,12 @@ extension ClientBootstrap: RSocketCore.ClientBootstrap {
                 }
             }
             .connect(host: endpoint.host, port: endpoint.port)
-
-        return connectFuture
-            .flatMap { _ in requesterPromise.futureResult }
-            .map(CoreClient.init)
+        return connectFuture.flatMap { channel in
+            requesterPromise.futureResult.map { socket in
+                // initializing core client using channel object
+                return CoreClient.init(requester: socket, channel: channel)
+            }
+        }
     }
 }
 

--- a/Tests/RSocketCoreTests/CoreClientTests.swift
+++ b/Tests/RSocketCoreTests/CoreClientTests.swift
@@ -1,18 +1,9 @@
-/*
- * Copyright 2015-present the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+//
+//  CoreClientTests.swift
+//  
+//
+//  Created by Ayush Yadav on 12/07/22.
+//
 
 import Foundation
 import XCTest
@@ -21,17 +12,20 @@ import NIO
 import RSocketTestUtilities
 class CoreClientTests: XCTestCase {
     /// Test case for closing Rsocket connection when core client will get deinitialize
-    func testCoreClientDeinitCloseConnectionSuccessTest() throws {
+    func testCoreClientDeinitCloseConnectionSuccessTest() {
         let channel = EmbeddedChannel()
-        try channel.connect(to: SocketAddress.init(ipAddress: "127.0.0.1", port: 0)).wait()
+       XCTAssertNoThrow(try channel.connect(to: SocketAddress.init(ipAddress: "127.0.0.1", port: 0)).wait())
         // initializing core client instance
         var  coreClient: CoreClient? = CoreClient(requester: TestRSocket(), channel: channel)
         XCTAssertNotNil(coreClient)
         // checking if connection is active
         XCTAssertTrue(channel.isActive)
+        // checking if connection is active
+        XCTAssertNoThrow(try coreClient?.shutDown().wait())
         // Deinitializing core client instance
         coreClient = nil
         // checking if connection is inactive
         XCTAssertFalse(channel.isActive)
     }
 }
+

--- a/Tests/RSocketCoreTests/CoreClientTests.swift
+++ b/Tests/RSocketCoreTests/CoreClientTests.swift
@@ -1,9 +1,18 @@
-//
-//  CoreClientTests.swift
-//  
-//
-//  Created by Ayush Yadav on 12/07/22.
-//
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import Foundation
 import XCTest
@@ -22,7 +31,7 @@ class CoreClientTests: XCTestCase {
         // checking if connection is active
         XCTAssertTrue(channel.isActive)
         // checking if connection is active
-        XCTAssertNoThrow(try coreClient?.shutDown().wait())
+        XCTAssertNoThrow(try coreClient?.shutdown().wait())
         // Deinitializing core client instance
         coreClient = nil
         // checking if connection is inactive

--- a/Tests/RSocketCoreTests/CoreClientTests.swift
+++ b/Tests/RSocketCoreTests/CoreClientTests.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import XCTest
+import NIO
+@testable import RSocketCore
+import RSocketTestUtilities
+class CoreClientTests: XCTestCase {
+    /// Test case for closing Rsocket connection when core client will get deinitialize
+    func testCoreClientDeinitCloseConnectionSuccessTest() throws {
+        let channel = EmbeddedChannel()
+        try channel.connect(to: SocketAddress.init(ipAddress: "127.0.0.1", port: 0)).wait()
+        // initializing core client instance
+        var  coreClient: CoreClient? = CoreClient(requester: TestRSocket(), channel: channel)
+        XCTAssertNotNil(coreClient)
+        // checking if connection is active
+        XCTAssertTrue(channel.isActive)
+        // Deinitializing core client instance
+        coreClient = nil
+        // checking if connection is inactive
+        XCTAssertFalse(channel.isActive)
+    }
+}

--- a/Tests/RSocketCoreTests/CoreClientTests.swift
+++ b/Tests/RSocketCoreTests/CoreClientTests.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 import XCTest
-import NIO
+import NIOEmbedded
+import NIOCore
 @testable import RSocketCore
 import RSocketTestUtilities
 class CoreClientTests: XCTestCase {

--- a/Tests/RSocketCoreTests/EndToEndTests.swift
+++ b/Tests/RSocketCoreTests/EndToEndTests.swift
@@ -505,42 +505,4 @@ class EndToEndTests: XCTestCase {
         _ = requester.stream(payload: "Hello World!", initialRequestN: .max, responderStream: input)
         self.wait(for: [request, response, responseError], timeout: 1)
     }
-    
-    /**
-     Test case for closing Rsocket connection using channel instance api
-     channel.close(promise: nil) closes the Rsocket connection
-     channel.closeFuture.wait() - required to hold the thread untill connection will not close successfully.helpful to make
-     code sync.
-     */
-    func testRsocketConnectionCloseSuccess() throws{
-        let setup = ClientConfiguration(
-            timeout: .init(
-                timeBetweenKeepaliveFrames: 500,
-                maxLifetime: 5000
-            ), encoding: .init(
-                metadata: .applicationJson,
-                data: .messageXRSocketRoutingV0
-            )
-        )
-        let clientDidConnect = self.expectation(description: "client did connect to server")
-        
-        let server = makeServerBootstrap(shouldAcceptClient: { clientInfo in
-            XCTAssertEqual(clientInfo.timeBetweenKeepaliveFrames, Int32(setup.timeout.timeBetweenKeepaliveFrames))
-            XCTAssertEqual(clientInfo.maxLifetime, Int32(setup.timeout.maxLifetime))
-            XCTAssertEqual(clientInfo.encoding.metadata, setup.encoding.metadata)
-            XCTAssertEqual(clientInfo.encoding.data, setup.encoding.data)
-           clientDidConnect.fulfill()
-            return .accept
-        })
-        let port = try XCTUnwrap(try server.bind(host: host, port: 0).wait().localAddress?.port)
-        
-        let channel = try makeClientBootstrap(config: setup)
-            .connect(host: host, port: port)
-            .wait()
-        XCTAssertTrue(channel.isActive)
-        self.wait(for: [clientDidConnect], timeout: 5)
-        channel.close(promise: nil)
-        try channel.closeFuture.wait()
-        XCTAssertFalse(channel.isActive)
-    }
 }

--- a/Tests/RSocketCoreTests/EndToEndTests.swift
+++ b/Tests/RSocketCoreTests/EndToEndTests.swift
@@ -172,42 +172,6 @@ class EndToEndTests: XCTestCase {
         XCTAssertTrue(channel.isActive)
         self.wait(for: [clientDidConnect], timeout: 1)
     }
-    /* test case for closing Rsocket connection using channel instance api
-     * channel.close(promise: nil) closes the Rsocket connection
-     * channel.closeFuture.wait() - required to hold the thread untill connection will not close successfully.helpful to make
-       code sync.
-     */
-    func testRsocketConnectionCloseSuccess() throws{
-        let setup = ClientConfiguration(
-            timeout: .init(
-                timeBetweenKeepaliveFrames: 500,
-                maxLifetime: 5000
-            ), encoding: .init(
-                metadata: .applicationJson,
-                data: .messageXRSocketRoutingV0
-            )
-        )
-        let clientDidConnect = self.expectation(description: "client did connect to server")
-        
-        let server = makeServerBootstrap(shouldAcceptClient: { clientInfo in
-            XCTAssertEqual(clientInfo.timeBetweenKeepaliveFrames, Int32(setup.timeout.timeBetweenKeepaliveFrames))
-            XCTAssertEqual(clientInfo.maxLifetime, Int32(setup.timeout.maxLifetime))
-            XCTAssertEqual(clientInfo.encoding.metadata, setup.encoding.metadata)
-            XCTAssertEqual(clientInfo.encoding.data, setup.encoding.data)
-           clientDidConnect.fulfill()
-            return .accept
-        })
-        let port = try XCTUnwrap(try server.bind(host: host, port: 0).wait().localAddress?.port)
-        
-        let channel = try makeClientBootstrap(config: setup)
-            .connect(host: host, port: port)
-            .wait()
-        XCTAssertTrue(channel.isActive)
-        self.wait(for: [clientDidConnect], timeout: 5)
-        channel.close(promise: nil)
-        try channel.closeFuture.wait()
-        XCTAssertFalse(channel.isActive)
-    }
     func testMetadataPush() throws {
         let request = self.expectation(description: "receive request")
         let requester = try setupAndConnectServerAndClient(
@@ -540,5 +504,43 @@ class EndToEndTests: XCTestCase {
         })
         _ = requester.stream(payload: "Hello World!", initialRequestN: .max, responderStream: input)
         self.wait(for: [request, response, responseError], timeout: 1)
+    }
+    
+    /**
+     Test case for closing Rsocket connection using channel instance api
+     channel.close(promise: nil) closes the Rsocket connection
+     channel.closeFuture.wait() - required to hold the thread untill connection will not close successfully.helpful to make
+     code sync.
+     */
+    func testRsocketConnectionCloseSuccess() throws{
+        let setup = ClientConfiguration(
+            timeout: .init(
+                timeBetweenKeepaliveFrames: 500,
+                maxLifetime: 5000
+            ), encoding: .init(
+                metadata: .applicationJson,
+                data: .messageXRSocketRoutingV0
+            )
+        )
+        let clientDidConnect = self.expectation(description: "client did connect to server")
+        
+        let server = makeServerBootstrap(shouldAcceptClient: { clientInfo in
+            XCTAssertEqual(clientInfo.timeBetweenKeepaliveFrames, Int32(setup.timeout.timeBetweenKeepaliveFrames))
+            XCTAssertEqual(clientInfo.maxLifetime, Int32(setup.timeout.maxLifetime))
+            XCTAssertEqual(clientInfo.encoding.metadata, setup.encoding.metadata)
+            XCTAssertEqual(clientInfo.encoding.data, setup.encoding.data)
+           clientDidConnect.fulfill()
+            return .accept
+        })
+        let port = try XCTUnwrap(try server.bind(host: host, port: 0).wait().localAddress?.port)
+        
+        let channel = try makeClientBootstrap(config: setup)
+            .connect(host: host, port: port)
+            .wait()
+        XCTAssertTrue(channel.isActive)
+        self.wait(for: [clientDidConnect], timeout: 5)
+        channel.close(promise: nil)
+        try channel.closeFuture.wait()
+        XCTAssertFalse(channel.isActive)
     }
 }

--- a/Tests/RSocketReactiveSwiftTests/RSocketReactiveSwiftTests.swift
+++ b/Tests/RSocketReactiveSwiftTests/RSocketReactiveSwiftTests.swift
@@ -19,8 +19,8 @@ import NIOCore
 import ReactiveSwift
 import RSocketCore
 import RSocketTestUtilities
+import NIOEmbedded
 @testable import RSocketReactiveSwift
-import NIO
 extension ByteBuffer: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         self.init(string: value)


### PR DESCRIPTION
Added Dispose api for closing channel socket connection

### Motivation:

Once  we connect a socket channel connection successfully  , we need an api to close the channel connection.

### Modifications:

Added the channel reference in RSocketNIOChannel/ClientBootstrap.swift file.
Added dispose() method to close channel in  ClientBootstrap.swift file.
Added testRsocketConnectionCloseSuccess() test in RSocketCoreTests/EndToEndTests.swift file.

### Result:

We can now easily make request for closing connection.
