### PR TITLE
fixes invalid url crash

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -112,7 +112,8 @@ let package = Package(
         .testTarget(name: "RSocketTSChannelTests", dependencies: [
             "RSocketTSChannel",
             "RSocketWSTransport",
-            "RSocketTestUtilities"
+            "RSocketTestUtilities",
+            .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
         ]),
         // Examples
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -104,7 +104,16 @@ let package = Package(
         .testTarget(name: "RSocketWSTransportTests", dependencies: [
             "RSocketWSTransport"
         ]),
-        
+        .testTarget(name: "RSocketNIOChannelTests", dependencies: [
+            "RSocketNIOChannel",
+            "RSocketWSTransport",
+            "RSocketTestUtilities"
+        ]),
+        .testTarget(name: "RSocketTSChannelTests", dependencies: [
+            "RSocketTSChannel",
+            "RSocketWSTransport",
+            "RSocketTestUtilities"
+        ]),
         // Examples
         .executableTarget(
             name: "TimerClientExample",

--- a/Package.swift
+++ b/Package.swift
@@ -113,7 +113,7 @@ let package = Package(
             "RSocketTSChannel",
             "RSocketWSTransport",
             "RSocketTestUtilities",
-            .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
+            "RSocketCore"
         ]),
         // Examples
         .executableTarget(

--- a/Sources/RSocketNIOChannel/ClientBootstrap.swift
+++ b/Sources/RSocketNIOChannel/ClientBootstrap.swift
@@ -94,5 +94,11 @@ extension ClientBootstrap: RSocketCore.ClientBootstrap {
                 return CoreClient.init(requester: socket, channel: channel)
             }
         }
+        .flatMapError { error in
+            // Invalid url will not complete connection it will create leak promise so we need to capture error
+            // and pass to promise to avoid crash
+            requesterPromise.fail(error)
+            return connectFuture.eventLoop.makeFailedFuture(error)
+        }
     }
 }

--- a/Sources/RSocketNIOChannel/ClientBootstrap.swift
+++ b/Sources/RSocketNIOChannel/ClientBootstrap.swift
@@ -88,17 +88,12 @@ extension ClientBootstrap: RSocketCore.ClientBootstrap {
                 }
             }
             .connect(host: endpoint.host, port: endpoint.port)
+        connectFuture.cascadeFailure(to: requesterPromise)
         return connectFuture.flatMap { channel in
             requesterPromise.futureResult.map { socket in
                 // initializing core client using channel object
                 return CoreClient.init(requester: socket, channel: channel)
             }
-        }
-        .flatMapError { error in
-            // Invalid url will not complete connection it will create leak promise so we need to capture error
-            // and pass to promise to avoid crash
-            requesterPromise.fail(error)
-            return connectFuture.eventLoop.makeFailedFuture(error)
         }
     }
 }

--- a/Sources/RSocketTSChannel/ClientBootstrap.swift
+++ b/Sources/RSocketTSChannel/ClientBootstrap.swift
@@ -82,17 +82,12 @@ extension ClientBootstrap: RSocketCore.ClientBootstrap {
                 }
             }
             .connect(host: endpoint.host, port: endpoint.port)
+        connectFuture.cascadeFailure(to: requesterPromise)
         return connectFuture.flatMap { channel in
             requesterPromise.futureResult.map { socket in
                 // initializing core client using channel object
                 return CoreClient.init(requester: socket, channel: channel)
             }
-        }
-        .flatMapError { error in
-            // Invalid url will not complete connection it will create leak promise so we need to capture error
-            // and pass to promise to avoid crash
-            requesterPromise.fail(error)
-            return connectFuture.eventLoop.makeFailedFuture(error)
         }
     }
 }

--- a/Sources/RSocketTSChannel/ClientBootstrap.swift
+++ b/Sources/RSocketTSChannel/ClientBootstrap.swift
@@ -88,6 +88,12 @@ extension ClientBootstrap: RSocketCore.ClientBootstrap {
                 return CoreClient.init(requester: socket, channel: channel)
             }
         }
+        .flatMapError { error in
+            // Invalid url will not complete connection it will create leak promise so we need to capture error
+            // and pass to promise to avoid crash
+            requesterPromise.fail(error)
+            return connectFuture.eventLoop.makeFailedFuture(error)
+        }
     }
 }
 

--- a/Tests/RSocketNIOChannelTests/RSocketNIOChannelTests.swift
+++ b/Tests/RSocketNIOChannelTests/RSocketNIOChannelTests.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import RSocketNIOChannel
+import RSocketWSTransport
+import RSocketTestUtilities
+import RSocketCore
+class RSocketNIOChannelTests: XCTestCase {
+    var clientBootStrap: RSocketNIOChannel.ClientBootstrap<WSTransport>?
+    override func setUp() {
+        clientBootStrap = ClientBootstrap(
+            transport: WSTransport(),
+            config: .mobileToServer
+                .set(\.encoding.metadata, to: .messageXRSocketRoutingV0)
+                .set(\.encoding.data, to: .applicationJson)
+        )
+    }
+    /// test case for invalid url
+    func testInvalidUrlErrorCatch() {
+        let invalidUrlErrorCatch = expectation(description: "invalid url error catch")
+        let headerDict: [String: String] = ["": ""]
+        let uri = URL(string: "http://127.0.0.1/V1/Mock")!
+        // creating connection with invalid url
+        let bootstrap = clientBootStrap?.connect(to: WSTransport.Endpoint(url: uri, additionalHTTPHeader: headerDict),
+                                                 payload: Payload(metadata: "", data: ""), responder: TestRSocket())
+        // catch error on future fails
+        bootstrap?.whenFailure({ _ in
+            invalidUrlErrorCatch.fulfill()
+        })
+        self.wait(for: [invalidUrlErrorCatch], timeout: 0.1)
+    }
+}

--- a/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
+++ b/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import XCTest
 @testable import RSocketTSChannel
 import RSocketTestUtilities

--- a/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
+++ b/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
@@ -1,0 +1,37 @@
+//
+//  RSocketTSChannelTests.swift
+//
+//
+//  Created by Ayush Yadav on 25/08/22.
+//
+import XCTest
+@testable import RSocketTSChannel
+import RSocketTestUtilities
+import RSocketCore
+import RSocketWSTransport
+class RSocketTSChannelTests: XCTestCase {
+    var clientBootStrap: RSocketTSChannel.ClientBootstrap<WSTransport>?
+    override func setUp() {
+        clientBootStrap = ClientBootstrap(
+            transport: WSTransport(),
+            config: .mobileToServer
+                .set(\.encoding.metadata, to: .messageXRSocketRoutingV0)
+                .set(\.encoding.data, to: .applicationJson)
+        )
+    }
+    /// test case for invalid url
+    func testInvalidUrlErrorCatch() {
+        let invalidUrlErrorCatch = expectation(description: "invalid url error catch")
+        let headerDict: [String: String] = ["": ""]
+        let uri = URL(string: "http://127.0.0.1/V1/Mock")!
+        // creating connection with invalid url
+        let bootstrap = clientBootStrap?.connect(to: WSTransport.Endpoint(url: uri, additionalHTTPHeader: headerDict),
+                                                 payload: Payload(metadata: "", data: ""), responder: TestRSocket())
+        // catch error on future fails
+        bootstrap?.whenFailure({ _ in
+            invalidUrlErrorCatch.fulfill()
+        })
+        self.wait(for: [invalidUrlErrorCatch], timeout: 0.1)
+    }
+
+}

--- a/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
+++ b/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if canImport(Network)
 
 import XCTest
 @testable import RSocketTSChannel
@@ -20,6 +21,8 @@ import RSocketTestUtilities
 import RSocketCore
 import RSocketWSTransport
 import NIOTransportServices
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 class RSocketTSChannelTests: XCTestCase {
     var clientBootStrap: RSocketTSChannel.ClientBootstrap<WSTransport>?
     override func setUp() {
@@ -49,3 +52,5 @@ class RSocketTSChannelTests: XCTestCase {
     }
 
 }
+
+#endif

--- a/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
+++ b/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
@@ -1,9 +1,18 @@
-//
-//  RSocketTSChannelTests.swift
-//
-//
-//  Created by Ayush Yadav on 25/08/22.
-//
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import XCTest
 @testable import RSocketTSChannel
 import RSocketTestUtilities

--- a/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
+++ b/Tests/RSocketTSChannelTests/RSocketTSChannelTests.swift
@@ -19,6 +19,7 @@ import XCTest
 import RSocketTestUtilities
 import RSocketCore
 import RSocketWSTransport
+import NIOTransportServices
 class RSocketTSChannelTests: XCTestCase {
     var clientBootStrap: RSocketTSChannel.ClientBootstrap<WSTransport>?
     override func setUp() {
@@ -34,6 +35,9 @@ class RSocketTSChannelTests: XCTestCase {
         let invalidUrlErrorCatch = expectation(description: "invalid url error catch")
         let headerDict: [String: String] = ["": ""]
         let uri = URL(string: "http://127.0.0.1/V1/Mock")!
+        clientBootStrap?.configure {
+            $0.channelOption(NIOTSChannelOptions.waitForActivity, value: false)
+        }
         // creating connection with invalid url
         let bootstrap = clientBootStrap?.connect(to: WSTransport.Endpoint(url: uri, additionalHTTPHeader: headerDict),
                                                  payload: Payload(metadata: "", data: ""), responder: TestRSocket())


### PR DESCRIPTION
Handling invalid url connection crash.

**Motivation**:
Once we initiating connection with invalid url its creating a leaking promise and crashing. Need to avoid the crash once client uses invalid url for connection.

**Modifications**:
Added CascadeFailure in RSocketNIOChannel->ClientBootstrap.swift file.
Added CascadeFailure in RSocketTSChannel->ClientBootstrap.swift file.

**Result**:
Now Using invalid url will not create leaking promise crash.